### PR TITLE
tmpl8: don't try to keep cached clones shallow

### DIFF
--- a/tmpl8/src/render.rs
+++ b/tmpl8/src/render.rs
@@ -141,7 +141,7 @@ fn do_update_cache(cfg: &Config, cache_dir: &Path, force: bool) -> Result<()> {
                 if force || !(0..3600).contains(&age) {
                     run_command(
                         Command::new("git")
-                            .args(["pull", "--depth=1"])
+                            .arg("pull")
                             .stdout(stderr)
                             .current_dir(&path),
                     )?;


### PR DESCRIPTION
`git pull --depth=1` doesn't actually do this, and causes a fetch failure if the current remote `HEAD` isn't directly connected to our `HEAD`.  It appears that there isn't a clean way to prune the repo after fetching, so for now, just let commits accumulate.