### PR TITLE
tmpl8: add an option to render a single repository

### DIFF
--- a/tmpl8/src/main.rs
+++ b/tmpl8/src/main.rs
@@ -44,6 +44,9 @@ struct RenderArgs {
     /// Config file
     #[clap(short = 'c', long, value_name = "file", default_value = "config.yaml")]
     config: PathBuf,
+    /// Render only one repository
+    #[clap(short = 'r', long, value_name = "repo-name")]
+    repo: Option<String>,
 }
 
 #[derive(Debug, Parser)]

--- a/tmpl8/src/render.rs
+++ b/tmpl8/src/render.rs
@@ -31,7 +31,19 @@ use super::*;
 
 pub(super) fn render(args: RenderArgs) -> Result<()> {
     let cfg = Config::parse(&args.config)?;
-    for (path, data) in do_render(&args.config, &cfg)? {
+    if let Some(repo) = &args.repo {
+        if !cfg.repos.contains_key(repo) {
+            bail!("no such repo: {}", repo);
+        }
+    }
+
+    for (mut path, data) in do_render(&args.config, &cfg)? {
+        if let Some(repo) = &args.repo {
+            path = match path.strip_prefix(repo) {
+                Ok(p) => p.into(),
+                Err(_) => continue,  // file in another repo
+            }
+        }
         let path = args.output.join(path);
         let dir = path
             .parent()


### PR DESCRIPTION
When templates and their rendered output are stored in the same repo, it's useful to be able to render directly into the repo root, without having to construct a spurious parent directory to render into.