### PR TITLE
workflows: serialize sync runs

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+# Prevent multiple workflow runs from racing
+concurrency: ${{ github.workflow }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
If multiple PRs merge in quick succession, we don't want the sync jobs to race with each other.