### PR TITLE
go/release-checklist: note signing key changes in `release-notes.md`

### DIFF
--- a/go/release-checklist.md
+++ b/go/release-checklist.md
@@ -6,7 +6,8 @@ Release checklist:
 
 Tagging:
  - [ ] Write release notes in `docs/release-notes.md`. Get them reviewed and merged
-     - [ ] If doing a branched release, also include a PR to merge the `docs/release-notes.md` changes into main
+   - [ ] If the release signing key has changed because a new Fedora release has gone stable, note the change as done [here](https://github.com/coreos/{{ git_repo }}/releases/tag/{{ sample_signing_key_update_tag }}).
+   - [ ] If doing a branched release, also include a PR to merge the `docs/release-notes.md` changes into main
  - [ ] Ensure your local copy is up to date with the upstream main branch (`git@github.com:coreos/{{ git_repo }}.git`)
  - [ ] Ensure your working directory is clean (`git clean -fdx`)
  - [ ] Ensure you can sign commits and any yubikeys/smartcards are plugged in
@@ -54,7 +55,6 @@ GitHub release:
  - [ ] Verify the signatures
  - [ ] Find the new tag in the [GitHub tag list](https://github.com/coreos/{{ git_repo }}/tags) and click the triple dots menu, and create a draft release for it.
  - [ ] Upload all the release artifacts and their signatures. Copy and paste the release notes from `docs/release-notes.md` here as well.
-   - [ ] If the signing key has changed because a new Fedora release has gone stable, note the change in the GitHub release notes as done [here](https://github.com/coreos/{{ git_repo }}/releases/tag/{{ sample_signing_key_update_tag }}).
  - [ ] Publish the release
 
 Quay release:


### PR DESCRIPTION
Historically we've been noting key changes in the GitHub release but not in the release notes, which is confusing.  Do it in both places.