### PR TITLE
Diff against branch in pending PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
+FORK_ARGS = \
+	--fork-regex /coreos/ \
+	--fork-replacement /coreosbot-releng/ \
+	--fork-branch repo-templates
+
 .PHONY: diff
 diff: tmpl8
-	tmpl8/target/debug/tmpl8 diff | less -R
+	tmpl8/target/debug/tmpl8 diff $(FORK_ARGS) | less -R
 
 .PHONY: output
 output: tmpl8
@@ -9,7 +14,7 @@ output: tmpl8
 # Force sync of downstream repo cache
 .PHONY: sync
 sync: tmpl8
-	tmpl8/target/debug/tmpl8 update-cache
+	tmpl8/target/debug/tmpl8 update-cache $(FORK_ARGS)
 
 .PHONY: tmpl8
 tmpl8:

--- a/tmpl8/src/main.rs
+++ b/tmpl8/src/main.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
+use regex::Regex;
 
 mod github;
 mod render;
@@ -54,6 +55,8 @@ struct DiffArgs {
     /// Config file
     #[clap(short = 'c', long, value_name = "file", default_value = "config.yaml")]
     config: PathBuf,
+    #[clap(flatten)]
+    fork: ForkArgs,
     /// Disable color output
     #[clap(short = 'n', long)]
     no_color: bool,
@@ -64,6 +67,24 @@ struct UpdateCacheArgs {
     /// Config file
     #[clap(short = 'c', long, value_name = "file", default_value = "config.yaml")]
     config: PathBuf,
+    #[clap(flatten)]
+    fork: ForkArgs,
+}
+
+#[derive(Debug, Parser)]
+struct ForkArgs {
+    /// Regex for the upstream part of repo URL
+    #[clap(long = "fork-regex", value_name = "regex")]
+    #[clap(requires_all = &["replacement", "branch"])]
+    regex: Option<Regex>,
+    /// Replacement for upstream part of repo URL
+    #[clap(long = "fork-replacement", value_name = "string")]
+    #[clap(requires_all = &["regex", "branch"])]
+    replacement: Option<String>,
+    /// Fork branch
+    #[clap(long = "fork-branch", value_name = "branch")]
+    #[clap(requires_all = &["regex", "replacement"])]
+    branch: Option<String>,
 }
 
 #[derive(Debug, Parser)]

--- a/tmpl8/src/main.rs
+++ b/tmpl8/src/main.rs
@@ -84,3 +84,14 @@ fn main() -> Result<()> {
         Cmd::GithubMatrix(c) => github::get_matrix(c),
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use clap::IntoApp;
+
+    #[test]
+    fn clap_app() {
+        Cmd::command().debug_assert()
+    }
+}


### PR DESCRIPTION
We've been diffing against the downstream main branch, which creates an incentive to merge upstream template PRs expeditiously to keep the diff clean.  However, it also adds noise to the downstream Git history.  It'd be better to let changes accumulate in a PR, and merge it just before starting a release.

Add tmpl8 command-line options allowing it to sync the cache (and thus generate the diff) from the downstream PR branch instead.  If that branch is missing, fall back to the downstream main branch as before.  This is implemented via a regex and replacement string for repo URLs and a single branch name for all repos, since that's all we actually need right now.

Hardcode arguments in the Makefile to match the values used by the GitHub workflow.