### PR TITLE
workflows: check PRs for unreferenced templates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Install dependencies
-        run: dnf install -y cargo git-core
+        run: dnf install -y cargo git-core python3-pyyaml
+      - name: Check for unreferenced templates
+        run: |
+          python3 -c 'import yaml; print("\n".join(yaml.safe_load(open("config.yaml"))["templates"]))' |
+              sed 's/\.[a-z0-9]*$/.yaml/' > expected
+          stray=$(find . -path ./config.yaml -prune -o -name '*.yaml' -print |
+              sed 's:^\./::' |
+              grep -Fvxf expected ||:)
+          if [ -n "${stray}" ]; then
+              echo "Found template configs not referenced in config.yaml:"
+              echo "${stray}"
+              exit 1
+          fi
       - name: Build tmpl8 binary
         run: cd tmpl8 && cargo build
       - name: Sync cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     container: registry.fedoraproject.org/fedora:latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: dnf install -y cargo git-core
       - name: Build tmpl8 binary

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,7 +19,7 @@ jobs:
       matrix: ${{ steps.get.outputs.matrix }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: dnf install -y cargo
       - name: Build tmpl8 binary
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: dnf install -y git-core
       - name: Check out target repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ matrix.repo }}
           path: dest


### PR DESCRIPTION
Templates need to be mentioned in `config.yaml` to be applied.  Fail PR CI if we find unreferenced ones.