### PR TITLE
Add template GitHub Actions workflow to check for release note updates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -77,4 +77,5 @@ templates:
   - fcos/release-checklist.md
   - go/release-checklist.md
   - go/signing-ticket.sh
+  - release-notes/require-release-note.yml
   - rust/release-checklist.md

--- a/release-notes/require-release-note.yaml
+++ b/release-notes/require-release-note.yaml
@@ -1,0 +1,16 @@
+vars:
+  release_notes_path: docs/release-notes.md
+  release_notes_skip_label: skip-notes
+
+files:
+  - repo: afterburn
+    path: .github/workflows/require-release-note.yml
+
+  - repo: butane
+    path: .github/workflows/require-release-note.yml
+
+  - repo: coreos-installer
+    path: .github/workflows/require-release-note.yml
+
+  - repo: ignition
+    path: .github/workflows/require-release-note.yml

--- a/release-notes/require-release-note.yml
+++ b/release-notes/require-release-note.yml
@@ -1,0 +1,23 @@
+# Maintained in https://github.com/coreos/repo-templates
+# Do not edit downstream.
+
+name: Release notes
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  require-notes:
+    name: Require release note
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require release-notes.md update
+        uses: coreos/actions-lib/require-file-change@main
+        with:
+          path: {{ release_notes_path }}
+          override-label: {{ release_notes_skip_label }}


### PR DESCRIPTION
https://github.com/coreos/actions-lib/pull/3 adds a generic GitHub Action to check that PRs either update a specified file or set a label indicating that no update is needed.  Template an Actions workflow that invokes the new Action to ensure that PRs update release notes.