### PR TITLE
release-notes: serialize job runs within a PR

### DIFF
--- a/release-notes/require-release-note.yml
+++ b/release-notes/require-release-note.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: {% raw %}release-note-${{ github.ref }}{% endraw %}
+  cancel-in-progress: true
+
 jobs:
   require-notes:
     name: Require release note


### PR DESCRIPTION
GitHub can spawn multiple release note jobs at a time, e.g. if multiple labels are added to a PR.  https://github.com/coreos/actions-lib/pull/5 should avoid correctness issues, but the multiple runs are still redundant.  Terminate or cancel any previous runs when a new one is queued.