### PR TITLE
Add bootupd, ostree and rpm-ostree repos & bootupd to release checklist

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,15 @@ repos:
       rhel8_package: rust-afterburn
       rhel9_package: rust-afterburn
 
+  bootupd:
+    url: https://github.com/coreos/bootupd
+    vars:
+      git_repo: bootupd
+      crate: bootupd
+      fedora_package: rust-bootupd
+      rhel8_package: rust-bootupd
+      rhel9_package: rust-bootupd
+
   butane:
     url: https://github.com/coreos/butane
     vars:

--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,22 @@ repos:
       crate: openssh-keys
       fedora_package: rust-openssh-keys
 
+  ostree:
+    url: https://github.com/ostreedev/ostree
+    vars:
+      git_repo: ostree
+      fedora_package: ostree
+      rhel8_package: ostree
+      rhel9_package: ostree
+
+  rpm-ostree:
+    url: https://github.com/coreos/rpm-ostree
+    vars:
+      git_repo: rpm-ostree
+      fedora_package: rpm-ostree
+      rhel8_package: rpm-ostree
+      rhel9_package: rpm-ostree
+
   ssh-key-dir:
     url: https://github.com/coreos/ssh-key-dir
     vars:

--- a/rust/release-checklist.yaml
+++ b/rust/release-checklist.yaml
@@ -9,6 +9,9 @@ files:
     vars:
       do_release_notes_doc: true
 
+  - repo: bootupd
+    path: .github/ISSUE_TEMPLATE/release-checklist.md
+
   - repo: coreos-installer
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:


### PR DESCRIPTION
Add bootupd

See: https://github.com/coreos/repo-templates/issues/30

---

config: Add ostree & rpm-ostree

Those are weird cases where we have some rust but no crate.

---

rust: Filter vendor tarball by default
