### PR TITLE
rust: Filter vendor tarball by default

### DIFF
--- a/rust/release-checklist.yaml
+++ b/rust/release-checklist.yaml
@@ -1,6 +1,7 @@
 vars:
   do_fast_track: true
   do_release_digests: true
+  do_vendor_filter: true
   do_vendor_tarball: true
 
 files:
@@ -13,7 +14,6 @@ files:
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:
       do_release_notes_doc: true
-      do_vendor_filter: true
       do_ocp_mirror: true
 
   - repo: ignition-config-rs


### PR DESCRIPTION
We generally want to filter out non-Linux support from our vendor tarballs.