### PR TITLE
rust: manually tar up vendor directory to avoid changing tarball layout

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -74,7 +74,7 @@ Push access to the upstream repository is required in order to publish the new t
 {% if do_vendor_tarball %}
 - assemble vendor archive:
 {%- if do_vendor_filter %}
-  - [ ] `cargo vendor-filterer --format=tar.gz target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz`
+  - [ ] `cargo vendor-filterer target/vendor && tar czf target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz -C target vendor`
 {%- else %}
   - [ ] `cargo vendor target/vendor`
   - [ ] `find target/vendor -name '*.a' -delete`


### PR DESCRIPTION
Vendor tarballs generated by cargo-vendor-filterer place the individual crate directories at the root of the tarball, rather than in a `vendor` directory as we have previously done.  This is a breaking change that would require every downstream user of the tarball to adjust its build scripts.

Avoid the layout change by having cargo-vendor-filterer only generate a directory tree, and then manually creating the tarball from that.

Once cargo-vendor-filterer is fixed, we'll need to temporarily add an explicit checklist step to upgrade it before vendoring.  Otherwise we risk regressions in the tarball layout if the release engineer has an old version of the tool on their machine.

xref https://github.com/coreos/cargo-vendor-filterer/issues/27
cc @cgwalters 