### PR TITLE
Switch internal Kerberos realm to `IPA.REDHAT.COM`

### DIFF
--- a/go/release-checklist.md
+++ b/go/release-checklist.md
@@ -73,7 +73,7 @@ RHCOS packaging for the current RHCOS development release:
    - Run `go-mods-to-bundled-provides.py | sort` while inside of the `{{ git_repo }}` directory you ran `./tag_release` from & copy output into spec file in `# Main package provides` section
    - Update changelog
  - [ ] Run `spectool -g -S {{ rhel8_package }}.spec`
- - [ ] Run `kinit your_account@REDHAT.COM`
+ - [ ] Run `kinit your_account@IPA.REDHAT.COM`
  - [ ] Run `rhpkg new-sources $(spectool -S {{ rhel8_package }}.spec | sed 's:.*/::')`
  - [ ] PR the changes
  - [ ] Get the PR reviewed and merge it

--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -153,7 +153,7 @@ Push access to the upstream repository is required in order to publish the new t
     - remove any patches obsoleted by the new release
     - update changelog
   - [ ] run `spectool -g -S {{ rhel8_package }}.spec`
-  - [ ] run `kinit your_account@REDHAT.COM`
+  - [ ] run `kinit your_account@IPA.REDHAT.COM`
   - [ ] run `rhpkg new-sources $(spectool -S {{ rhel8_package }}.spec | sed 's:.*/::')`
   - [ ] PR the changes
   - [ ] get the PR reviewed and merge it


### PR DESCRIPTION
`REDHAT.COM` tickets are no longer accepted by `rhpkg`.