### PR TITLE
rust: switch back to generating tarballs with cargo-vendor-filterer

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -46,6 +46,9 @@ Push access to the upstream repository is required in order to publish the new t
 
 - make sure the project is clean and prepare the environment:
   - [ ] Make sure `cargo-release` is up to date: `cargo install cargo-release`
+{%- if do_vendor_tarball and do_vendor_filter %}
+  - [ ] Make sure `cargo-vendor-filterer` is up to date: `cargo install cargo-vendor-filterer`
+{%- endif %}
   - [ ] `cargo test --all-features`
   - [ ] `cargo clean`
   - [ ] `git clean -fd`
@@ -74,7 +77,7 @@ Push access to the upstream repository is required in order to publish the new t
 {% if do_vendor_tarball %}
 - assemble vendor archive:
 {%- if do_vendor_filter %}
-  - [ ] `cargo vendor-filterer target/vendor && tar czf target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz -C target vendor`
+  - [ ] `cargo vendor-filterer --format=tar.gz --prefix=vendor target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz`
 {%- else %}
   - [ ] `cargo vendor target/vendor`
   - [ ] `find target/vendor -name '*.a' -delete`


### PR DESCRIPTION
As of https://github.com/coreos/cargo-vendor-filterer/pull/29, cargo-vendor-filterer allows putting vendored crates in a top-level directory inside the tarball.  Drop our manual tar workaround and add a checklist item ensuring the release operator has the latest version of the tool.