### PR TITLE
Add GitHub workflow templates for building and pushing containers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,23 @@
 vars:
+  container_arches: [amd64, arm64]
+  container_needs_git_tags: false
   current_fedora: 36
   # Key ID from https://getfedora.org/security/
   current_fedora_signing_key: 38ab71f4
 
 repos:
+  11bot:
+    url: https://github.com/coreos/11bot
+    vars:
+      container_arches: [amd64]
+      containers: [quay.io/coreos/11bot]
+
+  airlock:
+    url: https://github.com/coreos/airlock
+    vars:
+      container_file: dist/Dockerfile
+      containers: [quay.io/coreos/airlock]
+
   afterburn:
     url: https://github.com/coreos/afterburn
     vars:
@@ -16,6 +30,8 @@ repos:
   butane:
     url: https://github.com/coreos/butane
     vars:
+      container_needs_git_tags: true
+      containers: [quay.io/coreos/butane, quay.io/coreos/fcct]
       git_repo: butane
       quay_repo: coreos/butane
       quay_legacy_repos: [coreos/fcct]
@@ -26,6 +42,7 @@ repos:
   coreos-installer:
     url: https://github.com/coreos/coreos-installer
     vars:
+      containers: [quay.io/coreos/coreos-installer]
       git_repo: coreos-installer
       crate: coreos-installer
       quay_repo: coreos/coreos-installer
@@ -39,6 +56,9 @@ repos:
   ignition:
     url: https://github.com/coreos/ignition
     vars:
+      container_file: Dockerfile.validate
+      container_needs_git_tags: true
+      containers: [quay.io/coreos/ignition-validate]
       git_repo: ignition
       quay_repo: coreos/ignition-validate
       fedora_package: ignition
@@ -58,6 +78,12 @@ repos:
       crate: openssh-keys
       fedora_package: rust-openssh-keys
 
+  rhcosbot:
+    url: https://github.com/coreos/rhcosbot
+    vars:
+      container_arches: [amd64]
+      containers: [quay.io/coreos/rhcosbot]
+
   ssh-key-dir:
     url: https://github.com/coreos/ssh-key-dir
     vars:
@@ -65,6 +91,12 @@ repos:
       crate: ssh-key-dir
       fedora_package: rust-ssh-key-dir
       rhel9_package: rust-ssh-key-dir
+
+  triagebot:
+    url: https://github.com/coreos/triagebot
+    vars:
+      container_arches: [amd64]
+      containers: [quay.io/coreos/triagebot]
 
   zincati:
     url: https://github.com/coreos/zincati
@@ -74,6 +106,7 @@ repos:
       fedora_package: rust-zincati
 
 templates:
+  - container/container.yml
   - fcos/release-checklist.md
   - go/release-checklist.md
   - go/signing-ticket.sh

--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,7 @@ repos:
 
 templates:
   - container/container.yml
+  - container/container-rebuild.yml
   - fcos/release-checklist.md
   - go/release-checklist.md
   - go/signing-ticket.sh

--- a/container/container-rebuild.yaml
+++ b/container/container-rebuild.yaml
@@ -1,0 +1,17 @@
+# This workflow is specifically for repos that maintain a versioned Docker
+# tag per Git tag, plus a 'release' tag that's aliased to the latest
+# versioned tag.  If there's a security update for the container base image,
+# we need to be able to update 'release' and create a new versioned tag
+# (e.g. 'v1.2.3-1') without creating a corresponding Git tag.
+#
+# Don't list repos that solely ship the main branch, since those can force a
+# rebuild by just pushing a commit.
+files:
+  - repo: butane
+    path: .github/workflows/container-rebuild.yml
+
+  - repo: coreos-installer
+    path: .github/workflows/container-rebuild.yml
+
+  - repo: ignition
+    path: .github/workflows/container-rebuild.yml

--- a/container/container-rebuild.yml
+++ b/container/container-rebuild.yml
@@ -1,16 +1,19 @@
 # Maintained in https://github.com/coreos/repo-templates
 # Do not edit downstream.
 
-{# Keep in sync with container-rebuild.yml. #}
+{# Keep in sync with container.yml. #}
 
-name: Container
+name: Rebuild release container
 
 on:
-  push:
-    branches: [{{ branches | join(sep=", ") }}]
-    tags: ["v*"]
-  pull_request:
-    branches: [{{ branches | join(sep=", ") }}]
+  workflow_dispatch:
+    inputs:
+      git-tag:
+        description: Existing Git tag
+        default: vX.Y.Z
+      docker-tag:
+        description: New Docker versioned tag
+        default: vX.Y.Z-1
 
 permissions:
   contents: read
@@ -26,8 +29,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-{%- if container_needs_git_tags %}
         with:
+          ref: {% raw %}${{ github.event.inputs.git-tag }}{% endraw %}
+{%- if container_needs_git_tags %}
           # fetch tags so the compiled-in version number is useful
           fetch-depth: 0
 {%- endif %}
@@ -40,8 +44,4 @@ jobs:
 {%- endif %}
           push: {{ containers | join(sep=" ") }}
           arches: {{ container_arches | join(sep=" ") }}
-{#- check whether container_arches != ['amd64'] (Tera can't compare arrays) #}
-{%-if container_arches.0 != 'amd64' or container_arches.1 %}
-          # Speed up PR CI by skipping non-amd64
-          pr-arches: amd64
-{%- endif %}
+          tags: {% raw %}${{ github.event.inputs.docker-tag }}{% endraw %} release

--- a/container/container.yaml
+++ b/container/container.yaml
@@ -1,0 +1,27 @@
+vars:
+  branches: [main]
+
+files:
+  - repo: 11bot
+    path: .github/workflows/container.yml
+
+  - repo: airlock
+    path: .github/workflows/container.yml
+
+  - repo: butane
+    path: .github/workflows/container.yml
+
+  - repo: coreos-installer
+    # legacy path
+    path: .github/workflows/containers.yml
+
+  - repo: ignition
+    path: .github/workflows/container.yml
+
+  - repo: rhcosbot
+    path: .github/workflows/container.yml
+
+  - repo: triagebot
+    path: .github/workflows/container.yml
+    vars:
+      branches: [main, bugzilla]

--- a/container/container.yml
+++ b/container/container.yml
@@ -1,0 +1,45 @@
+# Maintained in https://github.com/coreos/repo-templates
+# Do not edit downstream.
+
+name: Container
+
+on:
+  push:
+    branches: [{{ branches | join(sep=", ") }}]
+    tags: ["v*"]
+  pull_request:
+    branches: [{{ branches | join(sep=", ") }}]
+
+permissions:
+  contents: read
+
+# avoid races when pushing containers built from main
+concurrency:
+  group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}
+
+jobs:
+  build-container:
+    name: Build container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+{%- if container_needs_git_tags %}
+        with:
+          # fetch tags so the compiled-in version number is useful
+          fetch-depth: 0
+{%- endif %}
+      - name: Build and push container
+        uses: coreos/actions-lib/build-container@main
+        with:
+          credentials: {% raw %}${{ secrets.QUAY_AUTH }}{% endraw %}
+{%-if container_file %}
+          file: {{ container_file }}
+{%- endif %}
+          push: {{ containers | join(sep=" ") }}
+          arches: {{ container_arches | join(sep=" ") }}
+{#- check whether container_arches != ['amd64'] (Tera can't compare arrays) #}
+{%-if container_arches.0 != 'amd64' or container_arches.1 %}
+          # Speed up PR CI by skipping non-amd64
+          pr-arches: amd64
+{%- endif %}


### PR DESCRIPTION
Onboard our stock container-building workflow.  We don't add every container-building repo here, just the ones that already follow a common template.

Explicitly set the `arches` parameter even when we're using the `actions-lib/build-container` default.  Since we're templating the configs, we can be a bit more verbose, and the workflow files are clearer when we don't depend on a default from `actions-lib`.

Once we've done that, if there's a security issue in a container base image, we need to be able to rebuild the container and update the registry tag that users are using.  For repos without Git tags, there's just `latest`/`main` and we can update it by pushing a commit.  But for repos with a `release` tag aliased to a versioned tag built from a Git tag, we need a way to create a new registry tag and point `release` at it without having to tag a new upstream release in Git.

Thus, add a new workflow that takes an existing Git tag `vX.Y.Z` and a new registry tag `vX.Y.Z-A` as input, builds the container, pushes it to the new tag, and aliases `release` to it.  Enable it in the three upstream repos that might potentially need it.

Requires https://github.com/coreos/actions-lib/pull/8.