### PR TITLE
container: fix version strings in Ignition/Butane release containers

### DIFF
--- a/container/container-rebuild.yml
+++ b/container/container-rebuild.yml
@@ -34,6 +34,12 @@ jobs:
 {%- if container_needs_git_tags %}
           # fetch tags so the compiled-in version number is useful
           fetch-depth: 0
+      # If we're running on a signed tag, actions/checkout rewrites it into
+      # a lightweight tag (!!!) which "git describe" then ignores.  Rewrite
+      # it back.
+      # https://github.com/actions/checkout/issues/290
+      - name: Fix actions/checkout synthetic tag
+        run: git fetch --tags --force
 {%- endif %}
       - name: Build and push container
         uses: coreos/actions-lib/build-container@main

--- a/container/container.yml
+++ b/container/container.yml
@@ -30,6 +30,12 @@ jobs:
         with:
           # fetch tags so the compiled-in version number is useful
           fetch-depth: 0
+      # If we're running on a signed tag, actions/checkout rewrites it into
+      # a lightweight tag (!!!) which "git describe" then ignores.  Rewrite
+      # it back.
+      # https://github.com/actions/checkout/issues/290
+      - name: Fix actions/checkout synthetic tag
+        run: git fetch --tags --force
 {%- endif %}
       - name: Build and push container
         uses: coreos/actions-lib/build-container@main


### PR DESCRIPTION
    $ podman run --rm quay.io/coreos/butane:v0.16.0 --version
    Butane v0.15.0-62-g0a3904d

It turns out that when `actions/checkout` is told to check out a tag, it checks out the correct commit, but replaces the tag with a lightweight tag that it invents out of whole cloth (!!), apparently to handle the case where the tag was moved before we fetched it (?).  The Ignition and Butane build scripts compute the version string with `git describe`, which ignores that lightweight tag, so we end up with a version string derived from the previous release rather than the one that we're explicitly building.

Re-fetch the tag, as recommended in the `actions/checkout` issue, to get the real tag back.

xref https://github.com/actions/checkout/issues/290