### PR TITLE
Enable ShellCheck for Ignition

### DIFF
--- a/shellcheck/script.sh
+++ b/shellcheck/script.sh
@@ -21,7 +21,7 @@ main() {
             shellcheck --external-sources --shell bash --severity="${severity}" "${f}" || found_errors="true"
             bash -n "${f}" || found_errors="true"
         fi
-    done< <(find . -path "./.git" -prune -o -type f -print0)
+    done< <(find . -path "./.git" -prune -o -path "./vendor" -prune -o -type f -print0)
 
     if [[ "${found_errors}" != "false" ]]; then
         echo "[+] Found errors with ShellCheck"

--- a/shellcheck/script.yaml
+++ b/shellcheck/script.yaml
@@ -4,3 +4,6 @@ files:
 
   - repo: fedora-coreos-config
     path: ci/shellcheck
+
+  - repo: ignition
+    path: ci/shellcheck

--- a/shellcheck/workflow.yaml
+++ b/shellcheck/workflow.yaml
@@ -10,3 +10,9 @@ files:
     vars:
       branches:
         - testing-devel
+
+  - repo: ignition
+    path: .github/workflows/shellcheck.yml
+    vars:
+      branches:
+        - main


### PR DESCRIPTION
Enable ShellCheck for Ignition

See: https://github.com/coreos/ignition/pull/1549

---

shellcheck/script.sh: Also ignore ./vendor dir

Useful for Go repos with a `./vendor` directory.