### PR TITLE
Enable ShellCheck for coreos-installer-dracut

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,6 +55,11 @@ repos:
       rhel8_package: coreos-installer
       rhel9_package: rust-coreos-installer
 
+  coreos-installer-dracut:
+    url: https://github.com/coreos/coreos-installer-dracut
+    vars:
+      git_repo: coreos-installer-dracut
+
   fedora-coreos-config:
     url: https://github.com/coreos/fedora-coreos-config
     vars:

--- a/shellcheck/script.yaml
+++ b/shellcheck/script.yaml
@@ -5,5 +5,8 @@ files:
   - repo: coreos-installer
     path: ci/shellcheck
 
+  - repo: coreos-installer-dracut
+    path: ci/shellcheck
+
   - repo: fedora-coreos-config
     path: ci/shellcheck

--- a/shellcheck/workflow.yaml
+++ b/shellcheck/workflow.yaml
@@ -11,6 +11,12 @@ files:
       branches:
         - main
 
+  - repo: coreos-installer-dracut
+    path: .github/workflows/shellcheck.yml
+    vars:
+      branches:
+        - main
+
   - repo: fedora-coreos-config
     path: .github/workflows/shellcheck.yml
     vars:


### PR DESCRIPTION
config.yaml: Add coreos-installer-dracut repo

---

Enable ShellCheck for coreos-installer-dracut

See: https://github.com/coreos/coreos-installer-dracut/pull/11

---

Based on https://github.com/coreos/repo-templates/pull/72 to make rebases easier.