### PR TITLE
go/release-checklist: drop Butane MacPorts package

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,6 @@ repos:
       quay_legacy_repos: [coreos/fcct]
       fedora_package: butane
       rhel8_package: butane
-      macports_package: sysutils/butane
 
   console-login-helper-messages:
     url: https://github.com/coreos/console-login-helper-messages

--- a/go/release-checklist.md
+++ b/go/release-checklist.md
@@ -84,8 +84,3 @@ RHCOS packaging for the current RHCOS development release:
 
 CentOS Stream 9 packaging:
   - [ ] Create a `rebase-c9s-{{ git_repo }}` issue in the internal team-operations repo and follow the steps there
-
-{% if macports_package -%}
-Housekeeping:
- - [ ] Ask bgilbert to update the [MacPorts package](https://github.com/macports/macports-ports/tree/master/{{ macports_package }})
-{%- endif %}


### PR DESCRIPTION
The package still exists, but I've dropped maintainership.  The FCOS docs [mention](https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/#_installing_via_macports) that the package is available in MacPorts, but I don't think it needs to be kept 100% current or maintained directly by the CoreOS WG. The package is [marked](https://github.com/macports/macports-ports/blob/60fcf499ab358aac11015a7d909544d4c5a2555f/sysutils/butane/Portfile#L9) `openmaintainer`, so anyone can submit an update PR when they want.