### PR TITLE
rust/release-checklist: add link for RHCOS spec file

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -141,7 +141,7 @@ Push access to the upstream repository is required in order to publish the new t
 
 {% if rhel8_package %}
 - RHCOS packaging:
-  - [ ] update the `{{ rhel8_package }}` spec file
+  - [ ] update the [spec file](https://gitlab.com/redhat/rhel/rpms/{{ rhel8_package }})
     - bump the `Version`
     - switch the `Release` back to `1%{?dist}`
     - remove any patches obsoleted by the new release


### PR DESCRIPTION
When I created the PR: https://github.com/coreos/repo-templates/pull/94, I forgot about the rust package which could use this info as well.