### PR TITLE
rust: test vendor tarball before releasing

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -46,7 +46,12 @@ Push access to the upstream repository is required in order to publish the new t
 
 - make sure the project is clean and prepare the environment:
   - [ ] Make sure `cargo-release` {% if do_vendor_tarball %}and `cargo-vendor-filterer` are{% else %}is{% endif %} up to date: `cargo install cargo-release{% if do_vendor_tarball %} cargo-vendor-filterer{% endif %}`
+{%- if do_vendor_tarball %}
+  - [ ] `cargo vendor-filterer target/vendor`
+  - [ ] `cargo test --all-features --config 'source.crates-io.replace-with="vv"' --config 'source.vv.directory="target/vendor"'`
+{%- else %}
   - [ ] `cargo test --all-features`
+{%- endif %}
   - [ ] `cargo clean`
   - [ ] `git clean -fd`
   - [ ] `RELEASE_VER=x.y.z`


### PR DESCRIPTION
We've had two cases of cargo-vendor-filterer creating incorrect tarballs:

https://github.com/coreos/cargo-vendor-filterer/issues/27
https://github.com/coreos/cargo-vendor-filterer/issues/71

With the current checklist flow, we don't notice until the upstream release is complete and we're doing a RHEL build with the vendored tarball, forcing us to make a second release with a fixed tarball. Catch this before release by generating a provisional vendor directory during the prep phase and running `cargo test` against it.