### PR TITLE
tmpl8: fix cache sync for repos that haven't been forked

### DIFF
--- a/tmpl8/src/cache.rs
+++ b/tmpl8/src/cache.rs
@@ -99,6 +99,9 @@ pub(super) fn do_update_cache(
                     remote_url,
                     fork.branch.as_ref().unwrap(),
                 ])
+                // disable password prompts so we don't block if the repo is
+                // missing
+                .env("GIT_ASKPASS", "/bin/true")
                 .stdout(stderr()?)
                 .current_dir(&path)
                 .status()


### PR DESCRIPTION
When syncing a cached Git repo, we try to pull from our fork's PR branch when possible.  This lets us generate diffs that exclude any changes already merged upstream, PRed downstream, but not yet landed downstream.

However, when onboarding a new Git repo, our fork is created by `sync.yml` after the upstream onboarding PR is merged.  Thus, if the fork is missing, the cache needs to fall back to the downstream default branch so upstream PR CI can pass.  There's existing code to do that, but it didn't account for the fact that GitHub pretends missing repos are private and asks for authentication.  Therefore we'd block at a password prompt:

    Username for 'https://github.com':

Disable password prompting during this fetch so the fallback can run.

Fixes #13.  Fixes https://github.com/coreos/repo-templates/issues/61.