### PR TITLE
shellcheck: fix typo in workflow step name

### DIFF
--- a/shellcheck/workflow.yml
+++ b/shellcheck/workflow.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
       # https://github.com/actions/checkout/issues/760
       - name: Mark git checkout as safe


### PR DESCRIPTION
While we're fixing this in the Go and Rust workflows, let's fix it here too.