### PR TITLE
workflows: correctly configure tmpl8 workspace path for caching

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,8 @@ jobs:
           fi
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tmpl8
       - name: Build tmpl8 binary
         run: cd tmpl8 && cargo build
       - name: Sync cache

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,6 +24,8 @@ jobs:
         run: dnf install -y cargo
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tmpl8
       - name: Build tmpl8 binary
         run: cd tmpl8 && cargo build
       - name: Render templates


### PR DESCRIPTION
tmpl8 isn't in the root of the repo, so its `target/` directory isn't either.  Configure rust-cache to look in the right place for dependencies to cache.