### PR TITLE
rust: replace `do_vendor_tarball` with top-level `library_crate` flag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -81,6 +81,7 @@ repos:
     vars:
       git_repo: envsubst-rs
       crate: envsubst
+      library_crate: true
       fedora_package: rust-envsubst
 
   fedora-coreos-cincinnati:
@@ -143,6 +144,7 @@ repos:
     vars:
       git_repo: ignition-config-rs
       crate: ignition-config
+      library_crate: true
       fedora_package: rust-ignition-config
 
   liboverdrop-rs:
@@ -150,6 +152,7 @@ repos:
     vars:
       git_repo: liboverdrop-rs
       crate: liboverdrop
+      library_crate: true
       fedora_package: rust-liboverdrop
 
   openat-ext:
@@ -164,6 +167,7 @@ repos:
     vars:
       git_repo: openssh-keys
       crate: openssh-keys
+      library_crate: true
       fedora_package: rust-openssh-keys
 
   pkg:
@@ -200,6 +204,7 @@ repos:
     vars:
       git_repo: stream-metadata-rust
       crate: coreos-stream-metadata
+      library_crate: true
 
   triagebot:
     url: https://github.com/coreos/triagebot
@@ -217,6 +222,7 @@ repos:
     vars:
       git_repo: vmw_backdoor-rs
       crate: vmw_backdoor
+      library_crate: true
       fedora_package: rust-vmw_backdoor
 
   zincati:

--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -7,7 +7,7 @@
 This project uses [cargo-release][cargo-release] in order to prepare new releases, tag and sign the relevant git commit, and publish the resulting artifacts to [crates.io][crates-io].
 The release process follows the usual PR-and-review flow, allowing an external reviewer to have a final check before publishing.
 
-{% if do_vendor_tarball %}
+{% if not library_crate %}
 In order to ease downstream packaging of Rust binaries, an archive of vendored dependencies is also provided (only relevant for offline builds).
 {% endif %}
 
@@ -20,7 +20,7 @@ This guide requires:
  * [GPG setup][GPG setup] and personal key for signing
  * `cargo` (suggested: latest stable toolchain from [rustup][rustup])
  * `cargo-release` (suggested: `cargo install -f cargo-release`)
-{%- if do_vendor_tarball %}
+{%- if not library_crate %}
  * `cargo vendor-filterer` (suggested: `cargo install -f cargo-vendor-filterer`)
 {%- endif %}
  * Write access to this GitHub project
@@ -45,12 +45,12 @@ Push access to the upstream repository is required in order to publish the new t
 {% endif %}
 
 - make sure the project is clean and prepare the environment:
-  - [ ] Make sure `cargo-release` {% if do_vendor_tarball %}and `cargo-vendor-filterer` are{% else %}is{% endif %} up to date: `cargo install cargo-release{% if do_vendor_tarball %} cargo-vendor-filterer{% endif %}`
-{%- if do_vendor_tarball %}
+  - [ ] Make sure `cargo-release` {% if library_crate %}is{% else %}and `cargo-vendor-filterer` are{% endif %} up to date: `cargo install cargo-release{% if not library_crate %} cargo-vendor-filterer{% endif %}`
+{%- if library_crate %}
+  - [ ] `cargo test --all-features`
+{%- else %}
   - [ ] `cargo vendor-filterer target/vendor`
   - [ ] `cargo test --all-features --config 'source.crates-io.replace-with="vv"' --config 'source.vv.directory="target/vendor"'`
-{%- else %}
-  - [ ] `cargo test --all-features`
 {%- endif %}
   - [ ] `cargo clean`
   - [ ] `git clean -fd`
@@ -76,7 +76,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `git push ${UPSTREAM_REMOTE} v${RELEASE_VER}`
   - [ ] `cargo publish`
 
-{% if do_vendor_tarball %}
+{% if not library_crate %}
 - assemble vendor archive:
   - [ ] `cargo vendor-filterer --format=tar.gz --prefix=vendor target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz`
 {% endif %}
@@ -88,13 +88,13 @@ Push access to the upstream repository is required in order to publish the new t
 {%- else %}
   - [ ] copy in the changelog from the release PR
 {%- endif %}
-{%- if do_vendor_tarball %}
+{%- if not library_crate %}
   - [ ] upload `target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz`
 {%- endif %}
 {%- if do_release_digests %}
   - [ ] record digests of local artifacts:
     - `sha256sum target/package/{{ crate }}-${RELEASE_VER}.crate`
-{%- if do_vendor_tarball %}
+{%- if not library_crate %}
     - `sha256sum target/{{ crate }}-${RELEASE_VER}-vendor.tar.gz`
 {%- endif %}
 {%- endif %}

--- a/rust/release-checklist.yaml
+++ b/rust/release-checklist.yaml
@@ -2,7 +2,6 @@ vars:
   do_fast_track: true
   do_release_digests: true
   do_release_notes_doc: true
-  do_vendor_tarball: true
 
 files:
   - repo: afterburn
@@ -18,27 +17,23 @@ files:
     vars:
       do_fast_track: false
       do_release_digests: false
-      do_vendor_tarball: false
 
   - repo: ignition-config-rs
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:
       do_fast_track: false
-      do_vendor_tarball: false
 
   - repo: liboverdrop-rs
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:
       do_fast_track: false
       do_release_digests: false
-      do_vendor_tarball: false
 
   - repo: openssh-keys
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:
       do_fast_track: false
       do_release_digests: false
-      do_vendor_tarball: false
 
   - repo: ssh-key-dir
     path: .github/ISSUE_TEMPLATE/release-checklist.md
@@ -48,14 +43,12 @@ files:
     vars:
       do_fast_track: false
       do_release_digests: false
-      do_vendor_tarball: false
 
   - repo: vmw_backdoor-rs
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:
       do_fast_track: false
       do_release_digests: false
-      do_vendor_tarball: false
 
   - repo: zincati
     path: .github/ISSUE_TEMPLATE/release-checklist.md


### PR DESCRIPTION
We always ship vendor tarballs for Rust applications and never ship them for Rust libraries.  Add a `library_crate` flag, for future broader use, and switch the conditionals over to use it.

No output change intended.