### PR TITLE
rust: run build/test/clippy with `--all-targets`

### DIFF
--- a/rust/tests.yml
+++ b/rust/tests.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
       - name: cargo build
-        run: cargo build
+        run: cargo build --all-targets
       - name: cargo test
-        run: cargo test
+        run: cargo test --all-targets
 {%- for feature in extended_test_features|default(value=[]) %}
       - name: cargo test ({{ feature }})
-        run: cargo test --features {{ feature }}
+        run: cargo test --all-targets --features {{ feature }}
 {%- endfor %}
   tests-release-stable:
     name: Tests (release), stable toolchain
@@ -58,9 +58,9 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
       - name: cargo build (release)
-        run: cargo build --release
+        run: cargo build --all-targets --release
       - name: cargo test (release)
-        run: cargo test --release
+        run: cargo test --all-targets --release
   tests-release-msrv:
     name: Tests (release), minimum supported toolchain
     runs-on: ubuntu-latest
@@ -82,9 +82,9 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
       - name: cargo build (release)
-        run: cargo build --release
+        run: cargo build --all-targets --release
       - name: cargo test (release)
-        run: cargo test --release
+        run: cargo test --all-targets --release
   linting:
     name: Lints, pinned toolchain
     runs-on: ubuntu-latest
@@ -101,7 +101,7 @@ jobs:
       - name: cargo fmt (check)
         run: cargo fmt -- --check -l
       - name: cargo clippy (warnings)
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
   tests-other-channels:
     name: Tests, unstable toolchain
     runs-on: ubuntu-latest
@@ -119,6 +119,6 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
       - name: cargo build
-        run: cargo build
+        run: cargo build --all-targets
       - name: cargo test
-        run: cargo test
+        run: cargo test --all-targets


### PR DESCRIPTION
By default, `cargo test` builds examples but does not test them (if any test cases exist) and `cargo clippy` does not check tests or examples. Run both with `--all-targets` to fix this.

Also run `cargo build` with `--all-targets`, since it's clearer if examples are built during the build phase rather than the test phase.