### PR TITLE
release-checklist: check aarch64 GCP runs

### DIFF
--- a/fcos/release-checklist.md
+++ b/fcos/release-checklist.md
@@ -62,7 +62,9 @@ Using the [the build browser for the `{{ stream }}` stream](https://builds.coreo
     - [ ] x86_64
     - [ ] aarch64
 - [ ] Check [kola Azure run](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-azure/) to make sure it didn't fail
-- [ ] Check [kola GCP run](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/) to make sure it didn't fail
+- [ ] Check [kola GCP runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/) to make sure they didn't fail
+    - [ ] x86_64
+    - [ ] aarch64
 
 # ⚠️ Release ⚠️
 


### PR DESCRIPTION
Part of https://github.com/coreos/fedora-coreos-tracker/issues/1377