### PR TITLE
rust: enable `updates-testing` repo in RPM test

### DIFF
--- a/rust/rpm-test.yml
+++ b/rust/rpm-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir rpms
           make -f .copr/Makefile srpm outdir=rpms
-          mock --rebuild rpms/*.src.rpm
+          mock --rebuild --enablerepo=updates-testing rpms/*.src.rpm
           find /var/lib/mock -wholename '*/result/*.rpm' | xargs mv -t rpms
       - name: Archive RPMs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The RPM test verifies that the package can build against the RPMs currently in Fedora.  If a dependency isn't packaged, or the packaged version is outside the version range allowed by `Cargo.toml`, the test will fail and block PR merge.  Strictly speaking this check is stronger than necessary, since a dependency problem wouldn't matter until we update the Fedora packaging for the next stable release, by which point the problem may have been fixed in Fedora.  But, it avoids packaging surprises.

Sometimes the test fails because of a Fedora change, in which case it blocks all PR merges in the repo until fixed.  But the fix is usually on the Fedora side, so we either need to wait for a Bodhi update to go stable by time (which leaves CI broken for a week) or farm Bodhi karma to get the update stabilized sooner.

Enable the `updates-testing` repo in the RPM test so Fedora fixes will rapidly propagate back to CI.  This slightly reduces the integrity of the test (which now builds against what will be in Fedora in a week or so), but that really only matters right before a release, and shouldn't add much risk even then.