### PR TITLE
release-checklist: update sanity check formatting

### DIFF
--- a/fcos/release-checklist.md
+++ b/fcos/release-checklist.md
@@ -61,8 +61,9 @@ Using the [the build browser for the `{{ stream }}` stream](https://builds.coreo
 - Check [kola OpenStack runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-openstack/) to make sure they didn't fail
     - [ ] x86_64
     - [ ] aarch64
-- [ ] Check [kola Azure run](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-azure/) to make sure it didn't fail
-- [ ] Check [kola GCP runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/) to make sure they didn't fail
+- Check [kola Azure run](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-azure/) to make sure it didn't fail
+    - [ ] x86_64
+- Check [kola GCP runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/) to make sure they didn't fail
     - [ ] x86_64
     - [ ] aarch64
 


### PR DESCRIPTION
Update the formatting for the kola azure and kola gcp runs to match the rest of the kola runs. This will also make it clear which arches to check for on kola azure.