### PR TITLE
go: sort filenames in list of signing outputs

### DIFF
--- a/go/signing-ticket.sh
+++ b/go/signing-ticket.sh
@@ -69,9 +69,15 @@ EOF
 
 After running this you should end up with a directory with files in it like:
 
+{# create array of map values for sorting #}
+{% set_global variant_values = [] %}
+{% for _, variant in signing_variants %}
+{% set_global variant_values = variant_values | concat(with=variant) %}
+{% endfor %}
+
 ```
 $ ls -1
-{%- for _, variant in signing_variants %}
+{%- for variant in variant_values | sort %}
 {{ signing_base }}-{{ variant }}
 {{ signing_base }}-{{ variant }}.asc
 {%- endfor %}


### PR DESCRIPTION
The bottom of the signing ticket has an example list of output files, but the list isn't in the order produced by `ls` because it's sorted by map keys, not values.  Sort by value to fix that.