### PR TITLE
rust: check `Cargo.toml` for unintended increases of lower version bounds

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -47,6 +47,9 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `git checkout -b pre-release-${RELEASE_VER}`
 {%- endif %}
 
+- check `Cargo.toml` for unintended de-supporting of older dependency versions:
+  - [ ] `git diff $(git describe --abbrev=0) Cargo.toml`
+
 {% if not library_crate %}
 - update all dependencies:
   - [ ] `cargo update`


### PR DESCRIPTION
Sometimes a Dependabot update will needlessly increase the minimum supported version of a dependency, and PR review won't catch it.  Add an additional check before starting a release.