### PR TITLE
rust: checklist wording improvement

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -47,7 +47,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] `git checkout -b pre-release-${RELEASE_VER}`
 {%- endif %}
 
-- check `Cargo.toml` for unintended de-supporting of older dependency versions:
+- check `Cargo.toml` for unintended increases of lower version bounds:
   - [ ] `git diff $(git describe --abbrev=0) Cargo.toml`
 
 {% if not library_crate %}


### PR DESCRIPTION
Forgot to use `-a` when amending.