### PR TITLE
docs: Update just-the-docs theme to 0.6.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,7 @@ kramdown:
     ndash: "--"
     mdash: "---"
 
-remote_theme: just-the-docs/just-the-docs@v0.5.3
+remote_theme: just-the-docs/just-the-docs@v0.6.0
 plugins:
   - jekyll-remote-theme
 


### PR DESCRIPTION
See: https://github.com/just-the-docs/just-the-docs/releases/tag/v0.6.0