### PR TITLE
release-checklist: wait until mirror.openshift.com is updated

### DIFF
--- a/go/release-checklist.md
+++ b/go/release-checklist.md
@@ -100,6 +100,7 @@ RHCOS packaging for the current RHCOS development release:
  - [ ] Update your local repo and run `rhpkg build`
 {%- if do_ocp_mirror %}
  - [ ] File ticket similar to [this one](https://issues.redhat.com/browse/ART-3711) to sync the new version to mirror.openshift.com
+ - [ ] Wait until mirror.openshift.com is updated and confirm the new version is correct
 {%- endif %}
 {% endif %}
 

--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -186,6 +186,7 @@ Push access to the upstream repository is required in order to publish the new t
   - [ ] update your local repo and run `rhpkg build`
 {%- if do_ocp_mirror %}
   - [ ] file ticket similar to [this one](https://issues.redhat.com/browse/ART-3772) to sync the new version to mirror.openshift.com
+  - [ ] wait until mirror.openshift.com is updated and confirm the new version is correct
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
We had an instance recently where we thought the release was done, but the ART ticket was blocked on more information and we didn't notice until much later when users started wondering where the new version was.

Let's hard require the ART ticket to be closed before we can close the release ticket.