### PR TITLE
Update golangci_lint to 1.55.1

### DIFF
--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -2,7 +2,7 @@ vars:
   do_go_lint: true
   do_go_mod: true
   # go_versions defined in ../config.yaml
-  golangci_lint_version: v1.52.2
+  golangci_lint_version: v1.55.1
   go_build_cmd: go build
   go_test_cmd: go test -v ./...
 


### PR DESCRIPTION
Found that the older version of golangci_lint was resulting in failing tests for go 1.21. With the latest version this seems to be resolved.