### PR TITLE
tests: update rust msrv 1.75

### DIFF
--- a/rust/tests.yaml
+++ b/rust/tests.yaml
@@ -1,5 +1,5 @@
 vars:
-  lint_toolchain: 1.71.0
+  lint_toolchain: 1.75.0
   msrv: auto
 
 files:


### PR DESCRIPTION
The nightly builds are starting to fail due to dependancy's which are waiting on msrv to be 1.75. Update 1.75 to fix CI for downstream repos.

See https://github.com/coreos/afterburn/actions/runs/9487991545/job/26145977379?pr=1083