### PR TITLE
release-checklist: add step to link promotion PR

### DIFF
--- a/fcos/release-checklist.md
+++ b/fcos/release-checklist.md
@@ -12,6 +12,7 @@ Edit the issue title to include today's date. Once the pipeline spits out the ne
 
 - [ ] Add the `ok-to-promote` label to the issue
 - [ ] Review the promotion PR against the `{{ stream }}` branch on https://github.com/coreos/fedora-coreos-config
+- [ ] Post a link to the PR as a comment to this issue
 - [ ] Once CI has passed, merge it
 
 <details>


### PR DESCRIPTION
Add a step to the FCOS release checklist to add a link to the promotion PR as a comment to the issue. This will ensure we cross reference the promotion PR with the specific release issue that created it.