### PR TITLE
test: update golangci-linter to latest

### DIFF
--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -2,7 +2,7 @@ vars:
   do_go_lint: true
   do_go_mod: true
   # go_versions defined in ../config.yaml
-  golangci_lint_version: v1.55.1
+  golangci_lint_version: v1.61.0
   go_build_cmd: go build
   go_test_cmd: go test -v ./...
 


### PR DESCRIPTION
As of golang 1.23 the golangci-linter needs to be updated to 1.60.1 See that here: https://github.com/golangci/golangci-lint/releases