### PR TITLE
Fix labels syntax

### DIFF
--- a/dependabot/dependabot.yml
+++ b/dependabot/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      labels: ["skip-notes"]
+    labels: ["skip-notes"]
     open-pull-requests-limit: 3
   - package-ecosystem: {% if dependabot_ecosystem != "auto" -%}
 {{ dependabot_ecosystem }}


### PR DESCRIPTION
Sorry my fault, see the error logs:

Dependabot encountered the following error when parsing your .github/dependabot.yml:
`The property '#/updates/0/schedule' contains additional properties ["labels"] outside of the schema when none are allowed`