### PR TITLE
Revert "build(deps): bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,7 +37,7 @@ jobs:
         id: get
         run: tmpl8/target/debug/tmpl8 github-matrix >> $GITHUB_OUTPUT
       - name: Upload rendered output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: rendered
           path: output.tar


### PR DESCRIPTION
Reverts coreos/repo-templates#252

This failed: https://github.com/coreos/repo-templates/actions/runs/11958253598

```
Run actions/download-artifact@v3
  with:
    name: rendered
  env:
    REPO_NAME: 11bot
/usr/bin/docker exec  0ff5a3[2](https://github.com/coreos/repo-templates/actions/runs/11958253598/job/33337388570#step:7:2)5d9b1750c4b8dbc8167d8d267[3](https://github.com/coreos/repo-templates/actions/runs/11958253598/job/33337388570#step:7:3)a05f5b79e6dc55df8d5c652[4](https://github.com/coreos/repo-templates/actions/runs/11958253598/job/33337388570#step:7:4)756328c sh -c "cat /etc/*release | grep ^ID"
Starting download for rendered
Error: Unable to find any artifacts for the associated workflow
```