### PR TITLE
Revert "github/workflows/sync: Add skip-notes label to sync PRs"

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -95,7 +95,6 @@ jobs:
           path: output/${{ env.REPO_NAME }}
           push-to-fork: coreosbot-releng/${{ env.REPO_NAME }}
           branch: repo-templates
-          labels: skip-notes
           commit-message: |
             Sync repo templates ⚙
 


### PR DESCRIPTION
Reverts coreos/repo-templates#267

It looks like this fails for some repos:

```
Create or update the pull request
  Attempting creation of pull request
  A pull request already exists for coreosbot-releng:repo-templates
  Fetching existing pull request
  Attempting update of pull request
  Updated pull request #54 (coreosbot-releng:repo-templates => main)
  Applying labels 'skip-notes'
  Error: Must have admin rights to Repository.
```

https://github.com/coreos/repo-templates/actions/runs/11973256772