### PR TITLE
rust/rpm-test: Run on Ubuntu 22.04 for now

### DIFF
--- a/rust/rpm-test.yml
+++ b/rust/rpm-test.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   test-rpm-build:
     name: "Build (Fedora)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: registry.fedoraproject.org/fedora:latest
       options: --privileged


### PR DESCRIPTION
Builds are failing on Ubuntu 24.04 due to a bug in mock/usermode [1].

Revert back to Ubuntu 22.04 for now, likely until we move to Packit for building test RPMs.

[1] https://github.com/coreos/afterburn/issues/1156

See: https://github.com/coreos/coreos-installer/issues/1589
See: https://github.com/coreos/afterburn/issues/1156