### PR TITLE
fcos/release.md: enable EARLY_ARCH_JOBS

### DIFF
--- a/fcos/release-checklist.md
+++ b/fcos/release-checklist.md
@@ -29,7 +29,7 @@ Sometimes you need to run the process manually like if you need to add an extra 
 
 ## Build
 
-- [ ] Start a [build job](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build/) (select `{{ stream }}`, leave all other defaults). This will automatically run multi-arch builds.
+- [ ] Start a [build job](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build/) (select `{{ stream }}` and enable `EARLY_ARCH_JOBS`, leave all other defaults). This will automatically run multi-arch builds.
 - Post links to the jobs as a comment to this issue
     - [ ] x86_64
     - [ ] aarch64 ([multi-arch build job](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build-arch/))


### PR DESCRIPTION
The default has changed for EARLY_ARCH_JOBS to false[0]. Update the release checklist to enable EARLY_ARCH_JOBS to match the previous process for quicker builds.

[0] https://github.com/coreos/fedora-coreos-pipeline/pull/1085

Depends on  https://github.com/coreos/fedora-coreos-pipeline/pull/1085