### PR TITLE
rust/tests: use fcos-buildroot container to lint rust

### DIFF
--- a/rust/tests.yml
+++ b/rust/tests.yml
@@ -28,6 +28,7 @@ jobs:
   tests-stable:
     name: Tests, stable toolchain
     runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -48,6 +49,7 @@ jobs:
   tests-release-stable:
     name: Tests (release), stable toolchain
     runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -64,6 +66,7 @@ jobs:
   tests-release-msrv:
     name: Tests (release), minimum supported toolchain
     runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -88,6 +91,7 @@ jobs:
   linting:
     name: Lints, pinned toolchain
     runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -105,6 +109,7 @@ jobs:
   tests-other-channels:
     name: Tests, unstable toolchain
     runs-on: ubuntu-latest
+    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
     continue-on-error: true
     strategy:
       matrix:


### PR DESCRIPTION
These changes were made downstream in https://github.com/coreos/zincati/commit/5b79f1559a38a4ae3c2197adf0b28ca9ac08cac0 so let's add the changes here to sync downstream instead.

"in https://github.com/coreos/zincati/commit/32d76f6a678228a4aa8239f08fec2a61cc588258 we added ostree bindings to parse image references, which in turn require glib-devel dependencies to build.

Let's use the fcos-buildroot container to run the CI so we have to maintain the correct set of dependencies in one place."