### PR TITLE
go: update go_versions to 1.23 and 1.24 and linter to 1.64.4

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ vars:
   current_fedora: 41
   # Key ID from https://fedoraproject.org/security/
   current_fedora_signing_key: e99d6ad1
-  go_versions: [1.22.x, 1.23.x]
+  go_versions: [1.23.x, 1.24.x]
 
 repos:
   11bot:

--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -2,7 +2,7 @@ vars:
   do_go_lint: true
   do_go_mod: true
   # go_versions defined in ../config.yaml
-  golangci_lint_version: v1.61.0
+  golangci_lint_version: v1.64.4
   go_build_cmd: go build
   go_test_cmd: go test -v ./...
 


### PR DESCRIPTION
go 1.22 is no longer in support. 