### PR TITLE
tests: update rust lint_toolchain 1.84.1

### DIFF
--- a/rust/tests.yaml
+++ b/rust/tests.yaml
@@ -1,5 +1,5 @@
 vars:
-  lint_toolchain: 1.75.0
+  lint_toolchain: 1.84.1
   msrv: auto
 
 files:


### PR DESCRIPTION
Afterburn build is failing due to dependancy's which are waiting on lint_toolchain to be 1.84.1. Update 1.84.1 to fix CI for downstream repos.

See: https://github.com/coreos/afterburn/actions/runs/13607099114/job/38039854721?pr=1171