### PR TITLE
CI: Separate gofmt check from linting step

### DIFF
--- a/go/tests.yml
+++ b/go/tests.yml
@@ -73,6 +73,19 @@ jobs:
 {%- endif %}
       run: {{ go_test_cmd }}
 {%- if do_go_lint %}
+    - name: Check Go formatting (gofmt)
+      shell: bash
+      run: |
+        GO_FILES=$(find . -name '*.go' -not -path "./vendor/*")
+        UNFORMATTED_FILES=$(gofmt -l $GO_FILES)
+
+        if [ -n "$UNFORMATTED_FILES" ]; then
+          echo "Go files are not formatted. Please run 'gofmt -w .' on your code."
+          gofmt -d $UNFORMATTED_FILES
+          exit 1
+        fi
+      
+      echo "All Go files are correctly formatted."
     - name: Run linter
       uses: golangci/golangci-lint-action@v8
 {%- if do_multi_os %}
@@ -80,9 +93,7 @@ jobs:
 {%- endif %}
       with:
         version: {{ golangci_lint_version }}
-        args: -E=gofmt --timeout=30m0s
 {%- endif %}
-
 {%- if go_generated_dirs %}
   regenerate:
     name: Regenerate


### PR DESCRIPTION
This PR separates the `gofmt` check from the main `golangci-lint `step.

This is necessary because the `golangci-lint-action` is hardcoded to use the `run` command and cannot be instructed to use `fmt`, making it unsuitable for formatting-only checks after the `golangci-lint `v2 update.

The new step provides clearer feedback by `gofmt -d` in the CI logs. The main linter is updated to exclude `gofmt` to prevent redundant work.

This is also related to the migration from golangci-lint `v1` to `v2` where the `gofmt `is used changed. You can check more about it here: https://golangci-lint.run/product/migration-guide/
