### PR TITLE
fcos/release-checklist.md: add check for kola-azure-aarch64

### DIFF
--- a/fcos/release-checklist.md
+++ b/fcos/release-checklist.md
@@ -66,8 +66,9 @@ Using the [the build browser for the `{{ stream }}` stream](https://builds.coreo
 - Check [kola OpenStack runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-openstack/) to make sure they didn't fail
     - [ ] x86_64
     - [ ] aarch64
-- Check [kola Azure run](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-azure/) to make sure it didn't fail
+- Check [kola Azure runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-azure/) to make sure they didn't fail
     - [ ] x86_64
+    - [ ] aarch64
 - Check [kola GCP runs](https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/kola-gcp/) to make sure they didn't fail
     - [ ] x86_64
     - [ ] aarch64


### PR DESCRIPTION
We are now running the kola-azure job with both x86_64 and aarch64 images. Add a check to verify the new aarch64 run has passed.

xref: https://github.com/coreos/fedora-coreos-pipeline/pull/1162