### PR TITLE
fix: Update golangci-lint version

### DIFF
--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -2,7 +2,7 @@ vars:
   do_go_lint: true
   do_go_mod: true
   # go_versions defined in ../config.yaml
-  golangci_lint_version: v2.1.6
+  golangci_lint_version: v1.64.7
   go_build_cmd: go build
   go_test_cmd: go test -v ./...
 


### PR DESCRIPTION
Fixes the golangci-lint version used in the CI workflow to a supported version, resolving compatibility errors with golangci-lint-action@v8.