### PR TITLE
fix: Upgrade golangci-lint to v2

### DIFF
--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -2,7 +2,7 @@ vars:
   do_go_lint: true
   do_go_mod: true
   # go_versions defined in ../config.yaml
-  golangci_lint_version: v1.64.7
+  golangci_lint_version: v2.1.6
   go_build_cmd: go build
   go_test_cmd: go test -v ./...
 


### PR DESCRIPTION
Upgrades golangci-lint to v2 so we can apply the necessary configuration changes for the v2 migration in each affected repository as it was done in Butane here https://github.com/coreos/butane/pull/609.

Here are the docs used for the migration: https://golangci-lint.run/product/migration-guide/