### PR TITLE
dependabot: group updates in a single PR

### DIFF
--- a/dependabot/dependabot.yml
+++ b/dependabot/dependabot.yml
@@ -26,3 +26,10 @@ gomod
       - {{ label }}
 {%- endfor %}
 {% endif %}
+    # Group all updates together in a single PR. We can remove some
+    # updates from a combined update PR via comments to dependabot:
+    # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-updates-with-comment-commands
+    groups:
+      build:
+        patterns:
+          - "*"


### PR DESCRIPTION
This reduces some noise if tests pass and allows us to do less click maintenance. It seems to be working well for COSA: https://github.com/coreos/coreos-assembler/pull/4188

If we end up in a situation where one update in the bunch is problematic we can interact through comments with dependabot and kick it out of the update into its own PR.