### PR TITLE
go/tests: only check gofmt on Linux

### DIFF
--- a/go/tests.yml
+++ b/go/tests.yml
@@ -74,6 +74,9 @@ jobs:
       run: {{ go_test_cmd }}
 {%- if do_go_lint %}
     - name: Check Go formatting (gofmt)
+{%- if do_multi_os %}
+      if: runner.os == 'Linux'
+{%- endif %}
       shell: bash
       run: |
         GO_FILES=$(find . -name '*.go' -not -path "./vendor/*")


### PR DESCRIPTION
On windows the different handling of line endings can cause gofmt to fail.

Fixes 641cbf5