### PR TITLE
Remove RHCOS steps from checklist

### DIFF
--- a/rust/release-checklist.md
+++ b/rust/release-checklist.md
@@ -168,25 +168,6 @@ Push access to the upstream repository is required in order to publish the new t
 {% endif %}
 {% endif %}
 
-{% if rhaos_package %}
-- RHCOS packaging:
-  - [ ] update the [spec file](https://gitlab.com/redhat/rhel/rpms/{{ rhaos_package }})
-    - bump the `Version`
-    - switch the `Release` back to `1%{?dist}`
-    - remove any patches obsoleted by the new release
-    - update changelog
-  - [ ] run `spectool -g -S {{ rhaos_package }}.spec`
-  - [ ] run `kinit your_account@IPA.REDHAT.COM`
-  - [ ] run `rhpkg new-sources $(spectool -S {{ rhaos_package }}.spec | sed 's:.*/::')`
-  - [ ] PR the changes
-  - [ ] get the PR reviewed and merge it
-  - [ ] update your local repo and run `rhpkg build`
-{%- if do_ocp_mirror %}
-  - [ ] file ticket similar to [this one](https://issues.redhat.com/browse/ART-3772) to sync the new version to mirror.openshift.com
-  - [ ] wait until mirror.openshift.com is updated and confirm the new version is correct
-{% endif %}
-{% endif %}
-
 {% if rhel9_package %}
 CentOS Stream 9 packaging:
   - [ ] Create a `rebase-c9s-{{ git_repo }}` issue in the internal team-operations repo and follow the steps there


### PR DESCRIPTION
To prevent confusion, we are removing these steps. As a general rule, we do not build for RHAOS anymore.