### PR TITLE
config.yaml: bump current fedora to Fedora 43

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,9 @@
 vars:
   container_arches: [amd64, arm64]
   container_needs_git_tags: false
-  current_fedora: 42
+  current_fedora: 43
   # Key ID from https://fedoraproject.org/security/
-  current_fedora_signing_key: 105ef944
+  current_fedora_signing_key: "31645531"
   go_versions: [1.24.x, 1.25.x]
 
 repos:


### PR DESCRIPTION
xref: https://github.com/coreos/fedora-coreos-tracker/issues/1935

EDIT:
yaml assumes the new signing key is an integer value instead of a string
because the Fedora 43 short hash doesn't contain any letters. Wrap the
signing key short hash in quotes to force a string type.