### PR TITLE
rust/bump cincinnati msrv

### DIFF
--- a/rust/tests.yaml
+++ b/rust/tests.yaml
@@ -21,7 +21,7 @@ files:
     path: .github/workflows/rust.yml
     vars:
       # not in Cargo.toml
-      msrv: 1.61.0
+      msrv: 1.84.0
 
   # ignition-config-rs is custom
 


### PR DESCRIPTION
The MSRV over there haven't been updated in ages. 
It works well with 1.84.0. let's update to that.