### PR TITLE
go: update to Go 1.25/1.26 and golangci-lint v2.11.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ vars:
   current_fedora: 43
   # Key ID from https://fedoraproject.org/security/
   current_fedora_signing_key: "31645531"
-  go_versions: [1.24.x, 1.25.x]
+  go_versions: [1.25.x, 1.26.x]
 
 repos:
   11bot:

--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -3,7 +3,7 @@ vars:
   do_go_mod: true
   do_go_test: true
   # go_versions defined in ../config.yaml
-  golangci_lint_version: v2.6.2
+  golangci_lint_version: v2.11.3
   go_build_cmd: go build
   go_test_cmd: go test -v ./...
 


### PR DESCRIPTION
Time to update go