### PR TITLE
Add OpenCode skills for repo onboarding and template enrollment

### DIFF
--- a/.opencode/skills/enroll-repo-in-template/SKILL.md
+++ b/.opencode/skills/enroll-repo-in-template/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: enroll-repo-in-template
+description: Enable an existing Tera template for a downstream repo in the repo-templates system
+---
+
+# Enroll Repo in Template
+
+## What it does
+
+1. Validates the repo exists in `config.yaml`
+2. Identifies all YAML config files for the chosen template
+3. Reads template defaults and existing entries to determine the pattern
+4. Adds the repo entry to each config YAML file in alphabetical order
+5. Applies any user-specified variable overrides
+6. Validates the rendered output with `make`
+
+## Prerequisites
+
+- The repo must already be registered in `config.yaml` under `repos:`
+- The template must already exist and be listed in `config.yaml` under `templates:`
+- Cargo must be available to build the `tmpl8` renderer (for validation)
+
+## Usage
+
+```bash
+# Interactive mode - will ask which template and repo
+/enroll-repo-in-template
+
+# Specify template and repo
+/enroll-repo-in-template --template shellcheck --repo coreos-assembler
+
+# With variable overrides
+/enroll-repo-in-template --template shellcheck --repo coreos-assembler --vars 'branches: [main, rhel-*]'
+```
+
+## Workflow
+
+### Step 1: Gather Inputs
+
+If the user did not provide arguments, determine the template and repo interactively.
+
+**Get the template name:**
+
+Read `config.yaml` and extract the `templates:` list to show available templates:
+
+```bash
+grep -A 100 '^templates:' config.yaml
+```
+
+Ask the user which template they want to enable if not specified.
+
+**Get the repo name:**
+
+Read `config.yaml` and extract the `repos:` list to show available repos:
+
+```bash
+grep -E '^\s{2}\w' config.yaml | sed 's/://g' | awk '{print $1}'
+```
+
+Ask the user which repo they want to enroll if not specified.
+
+### Step 2: Validate Prerequisites
+
+**Check repo exists in `config.yaml`:**
+
+```bash
+grep -q "^  REPO_NAME:" config.yaml
+```
+
+If the repo does NOT exist, stop and tell the user to add it first (or suggest running the "onboard-repo" skill if it exists).
+
+**Check template is registered:**
+
+Verify the template appears in the `templates:` list in `config.yaml`.
+
+**Check repo is not already enrolled:**
+
+For each template config YAML file, check that the repo is not already listed:
+
+```bash
+grep -q "repo: REPO_NAME" TEMPLATE_DIR/CONFIG.yaml
+```
+
+If already enrolled, inform the user and stop.
+
+### Step 3: Identify Template Config Files
+
+Templates may have one or more YAML config files. Determine which ones exist:
+
+```bash
+ls TEMPLATE_DIR/*.yaml
+```
+
+For example:
+- `shellcheck` has `script.yaml` AND `workflow.yaml` (both need entries)
+- `gemini` has just `config.yaml` (one entry needed)
+- `dependabot` has just `dependabot.yaml` (one entry needed)
+
+Read each YAML config file to understand:
+1. The default `vars:` at the top of the file
+2. The `path:` pattern used by existing entries
+3. Whether entries typically include `vars:` overrides
+
+### Step 4: Determine Entry Details
+
+For each config YAML file:
+
+1. **Determine the `path:`** - Look at existing entries. If all repos use the same path, use that. If paths vary, ask the user.
+
+2. **Determine `vars:` overrides** - Read the template-level `vars:` defaults. Ask the user if they need to override any variables. Present the available variables and their defaults.
+
+3. **Find insertion point** - Entries in the `files:` list should be in alphabetical order by repo name. Find the correct position.
+
+### Step 5: Edit the Config Files
+
+For each template config YAML file, use the Edit tool to insert the new entry.
+
+**Format for entry WITHOUT vars overrides:**
+```yaml
+
+  - repo: REPO_NAME
+    path: OUTPUT_PATH
+```
+
+**Format for entry WITH vars overrides:**
+```yaml
+
+  - repo: REPO_NAME
+    path: OUTPUT_PATH
+    vars:
+      VAR_NAME: VAR_VALUE
+```
+
+**Important formatting rules:**
+- Entries are separated by blank lines
+- Use 2-space indentation for the `- repo:` line (under `files:`)
+- Use 4-space indentation for `path:` and `vars:`
+- Use 6-space indentation for individual var key-value pairs
+- Maintain alphabetical order by repo name within the `files:` list
+- Match the exact indentation style used by surrounding entries
+
+### Step 6: Validate
+
+After making changes, validate the template renders correctly:
+
+```bash
+# Build the renderer if not already built
+cd tmpl8 && cargo build
+
+# Render all templates and show diffs
+make diff
+```
+
+Or just render the output tree:
+
+```bash
+make output
+```
+
+Check that:
+1. No rendering errors occurred
+2. The new repo's rendered file appears in `output/REPO_NAME/OUTPUT_PATH`
+3. The rendered content looks correct (template variables substituted properly)
+
+### Step 7: Report Results
+
+Tell the user:
+- Which files were modified
+- What the rendered output looks like
+- Remind them to commit, PR, and let CI validate
+
+## Template Quick Reference
+
+### Templates with a single config file (simple):
+- `container/container.yaml` -> `.github/workflows/container.yml`
+- `container/container-rebuild.yaml` -> `.github/workflows/container-rebuild.yml`
+- `copr/Makefile.yaml` -> `Makefile`
+- `dependabot/dependabot.yaml` -> `.github/dependabot.yml`
+- `fcos/release-checklist.yaml` -> `.github/ISSUE_TEMPLATE/{stream}.md`
+- `gemini/config.yaml` -> `.gemini/config.yaml`
+- `go/release-checklist.yaml` -> `.github/ISSUE_TEMPLATE/release-checklist.md`
+- `go/signing-ticket.yaml` -> `signing-ticket.sh`
+- `go/tag_release.yaml` -> `tag_release.sh`
+- `go/tests.yaml` -> `.github/workflows/go.yml`
+- `go/tests-ignition.yaml` -> `.github/workflows/go.yml`
+- `owners-file-action/owners-file-action.yaml` -> `.github/workflows/owners-file-action.yml`
+- `release-notes/require-release-note.yaml` -> `.github/workflows/require-release-note.yml`
+- `rust/release-checklist.yaml` -> `.github/ISSUE_TEMPLATE/release-checklist.md`
+- `rust/rpm-test.yaml` -> `.github/workflows/rpm-test.yml`
+- `rust/tests.yaml` -> `.github/workflows/rust.yml`
+
+### Templates with multiple config files (need entries in ALL):
+- `shellcheck/` -> `script.yaml` (path: `ci/shellcheck`) + `workflow.yaml` (path: `.github/workflows/shellcheck.yml`)
+- `find-whitespace/` -> `script.yaml` (path: `ci/find-whitespace`) + `workflow.yaml` (path: `.github/workflows/find-whitespace.yml`)
+- `docs/` -> `coreos.yaml` covers both `docs/_config.yml` and `docs/assets/css/coreos.scss`
+
+## Checklist Coverage
+
+This skill automates the following manual steps:
+
+- [x] Finding the correct template config YAML file(s)
+- [x] Understanding available variables and defaults
+- [x] Determining the correct output path
+- [x] Adding the entry in alphabetical order
+- [x] Handling multi-file templates consistently
+- [x] Validating the rendered output
+
+## What's NOT covered
+
+- Adding a new repo to `config.yaml` (use the "onboard-repo" skill or do manually)
+- Creating a brand new template type (different workflow)
+- Modifying template content (the `.yml` Tera template files themselves)
+- Pushing changes to remote or creating PRs
+
+## Example Output
+
+When you run `/enroll-repo-in-template --template gemini/config --repo fedora-coreos-pipeline`:
+
+```
+Validating prerequisites...
+  Repo 'fedora-coreos-pipeline' exists in config.yaml
+  Template 'gemini/config.yml' is registered in config.yaml
+  Repo is not already enrolled in gemini/config
+
+Reading template config: gemini/config.yaml
+  Default vars: branches: [main]
+  Common path: .gemini/config.yaml
+  Config files to update: 1
+
+Adding entry to gemini/config.yaml...
+  Inserted after 'fedora-coreos-config', before 'ignition'
+
+Validating render...
+  make output completed successfully
+  Output file: output/fedora-coreos-pipeline/.gemini/config.yaml
+
+Done! Files modified:
+  - gemini/config.yaml (+3 lines)
+
+Next steps:
+  1. Review the changes with 'git diff'
+  2. Commit and create a PR
+  3. CI will validate rendering and show diffs against downstream repos
+```
+
+## References
+
+- [DESIGN.md](DESIGN.md) - Detailed design document with analysis
+- [Example 1](examples/example-1-simple-enrollment.md) - Simple single-file enrollment
+- [Example 2](examples/example-2-multi-file-with-vars.md) - Multi-file enrollment with vars
+- [Example 3](examples/example-3-enrollment-with-custom-vars.md) - Enrollment with custom vars
+- `config.yaml` - Central registry of repos and templates
+- `README.md` - Template system architecture documentation

--- a/.opencode/skills/onboard-new-repo/SKILL.md
+++ b/.opencode/skills/onboard-new-repo/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: onboard-new-repo
+description: Add a new downstream repo to config.yaml so it can receive repo-templates
+---
+
+# Onboard New Repo
+
+## What it does
+
+1. Validates the repo is not already in `config.yaml`
+2. Determines the repo type (Go binary, Rust crate, container, minimal) and required vars
+3. Adds the repo entry to `config.yaml` in alphabetical order under `repos:`
+4. Optionally enrolls the repo in common templates (delegates to `enroll-repo-in-template`)
+5. Validates the rendered output with `make`
+
+## Prerequisites
+
+- The GitHub repo must exist (under the `coreos` org by convention)
+- Write access to this repo-templates repository
+
+## Usage
+
+```bash
+# Interactive mode
+/onboard-new-repo
+
+# Specify repo name and URL
+/onboard-new-repo --name my-project --url https://github.com/coreos/my-project
+
+# Specify type for automatic var population
+/onboard-new-repo --name my-project --url https://github.com/coreos/my-project --type rust-crate
+```
+
+## Workflow
+
+### Step 1: Gather Inputs
+
+If the user did not provide arguments, ask for:
+
+1. **Repo short name** - the key used in `config.yaml` (e.g., `chunkah`, `afterburn`). By convention this matches the GitHub repo name.
+2. **Repo URL** - full GitHub URL (e.g., `https://github.com/coreos/chunkah`). Almost always `https://github.com/coreos/<name>`.
+
+### Step 2: Validate Prerequisites
+
+**Check repo is not already registered:**
+
+Read `config.yaml` and verify the repo name does not already appear under `repos:`.
+
+If the repo already exists, inform the user and stop. Suggest using `enroll-repo-in-template` instead if they want to enable templates for it.
+
+### Step 3: Determine Repo Type and Vars
+
+Read `config.yaml` to understand the existing patterns. Ask the user what type of project this is, which determines which `vars` are needed:
+
+**Minimal** (e.g., `chunkah`, `toolbox`, `fedora-coreos-pipeline`):
+```yaml
+  repo-name:
+    url: https://github.com/coreos/repo-name
+    vars:
+      git_repo: repo-name
+```
+
+**Go project with packaging** (e.g., `butane`, `ignition`):
+```yaml
+  repo-name:
+    url: https://github.com/coreos/repo-name
+    vars:
+      git_repo: repo-name
+      fedora_package: repo-name
+      pretty_name: Repo Name
+      # Optional:
+      rhaos_package: repo-name
+      rhel9_package: repo-name
+      rhel10_package: repo-name
+```
+
+**Rust crate** (e.g., `afterburn`, `zincati`):
+```yaml
+  repo-name:
+    url: https://github.com/coreos/repo-name
+    vars:
+      git_repo: repo-name
+      crate: repo-name
+      fedora_package: rust-repo-name
+      pretty_name: Repo Name
+      # Optional:
+      library_crate: true          # if it's a library, not a binary
+      rhel9_package: rust-repo-name
+      rhel10_package: rust-repo-name
+```
+
+**Container project** (e.g., `11bot`, `rhcosbot`, `triagebot`):
+```yaml
+  repo-name:
+    url: https://github.com/coreos/repo-name
+    vars:
+      container_arches: [amd64]    # or [amd64, arm64]
+      containers: [quay.io/coreos/repo-name]
+      # Plus any of the above vars as needed
+```
+
+**Common vars reference** (all optional, add as needed):
+
+| Var | Description | Example |
+|-----|-------------|---------|
+| `git_repo` | Repo name, used in templates for URLs and paths | `afterburn` |
+| `crate` | Rust crate name on crates.io | `afterburn` |
+| `library_crate` | Set `true` for library crates (affects release checklist) | `true` |
+| `fedora_package` | Fedora package name | `rust-afterburn` |
+| `rhaos_package` | RHAOS package name | `butane` |
+| `rhel9_package` | RHEL 9 / CentOS Stream 9 package name | `rust-afterburn` |
+| `rhel10_package` | RHEL 10 / CentOS Stream 10 package name | `rust-afterburn` |
+| `pretty_name` | Human-readable name for release checklists | `Afterburn` |
+| `containers` | List of container image URLs | `[quay.io/coreos/afterburn]` |
+| `container_arches` | Architectures to build containers for | `[amd64, arm64]` |
+| `container_file` | Custom Dockerfile path (default: `Dockerfile`) | `dist/Dockerfile` |
+| `container_needs_git_tags` | Whether container build needs full git tags | `true` |
+| `quay_repo` | Quay.io repo path for release tagging | `coreos/butane` |
+| `quay_legacy_repos` | Legacy Quay repos that also need release tags | `[coreos/fcct]` |
+
+### Step 4: Insert Entry into config.yaml
+
+Add the new repo block to `config.yaml` under `repos:` in **alphabetical order** by repo name.
+
+**Formatting rules:**
+- 2-space indent for the repo name key
+- 4-space indent for `url:` and `vars:`
+- 6-space indent for individual var key-value pairs
+- Blank line before the repo block (to separate from the previous entry)
+- Repos are sorted alphabetically (e.g., `chunkah` comes after `cap-std-ext`, before `console-login-helper-messages`)
+
+Use the Edit tool to insert the new block at the correct alphabetical position. Find the repo entry that should come immediately AFTER the new one, and insert before it.
+
+### Step 5: Validate
+
+Build and render to verify:
+
+```bash
+cd tmpl8 && cargo build
+```
+
+```bash
+make output
+```
+
+Since the new repo has no templates enrolled yet, this should succeed without producing any output files for it. The key thing is that it doesn't break rendering for other repos.
+
+### Step 6: Suggest Next Steps
+
+After onboarding, tell the user:
+
+1. The repo is now registered and can receive templates
+2. Suggest common templates to enroll based on the repo type:
+   - **All repos**: `dependabot`, `gemini/config`
+   - **Go repos**: `go/tests`, `go/release-checklist`, `go/tag_release`, `go/signing-ticket`
+   - **Rust repos**: `rust/tests`, `rust/release-checklist`
+   - **Container repos**: `container/container`, `container/container-rebuild`
+   - **Repos with shell scripts**: `shellcheck`
+3. Suggest using the `enroll-repo-in-template` skill to enable templates
+
+## Example Entries by Complexity
+
+### Simplest (3 vars):
+```yaml
+  chunkah:
+    url: https://github.com/coreos/chunkah
+    vars:
+      git_repo: chunkah
+```
+*Reference: commit `20419ce`*
+
+### Rust library crate:
+```yaml
+  ignition-config-rs:
+    url: https://github.com/coreos/ignition-config-rs
+    vars:
+      git_repo: ignition-config-rs
+      crate: ignition-config
+      library_crate: true
+      fedora_package: rust-ignition-config
+```
+
+### Full Go project with containers and packaging:
+```yaml
+  butane:
+    url: https://github.com/coreos/ignition
+    vars:
+      container_needs_git_tags: true
+      containers: [quay.io/coreos/butane, quay.io/coreos/fcct]
+      git_repo: butane
+      repo_subdirectory: butane
+      tag_prefix: butane/
+      quay_repo: coreos/butane
+      quay_legacy_repos: [coreos/fcct]
+      fedora_package: butane
+      rhaos_package: butane
+      rhel9_package: butane
+      rhel10_package: butane
+      pretty_name: Butane
+      vendored_ignition_note: true
+```
+
+## Checklist Coverage
+
+- [x] Validating repo doesn't already exist
+- [x] Determining correct vars based on project type
+- [x] Inserting in alphabetical order
+- [x] Matching existing YAML formatting conventions
+- [x] Validating render doesn't break
+
+## What's NOT covered
+
+- Creating the actual GitHub repo
+- Enrolling in specific templates (use `enroll-repo-in-template` for that)
+- Setting up CI/CD in the downstream repo
+- Pushing changes or creating PRs
+
+## References
+
+- Example commits:
+  - `20419ce` - Add chunkah (minimal repo + gemini enrollment)
+  - `99d808f` - Add fedora-coreos-pipeline (minimal repo)
+  - `d21ed2f` - Add rhel-coreos-config (minimal repo + shellcheck enrollment)
+  - `075b5e5` - Add coreos-assembler & rpm-ostree (two minimal repos at once)
+- `config.yaml` - Central registry with all existing repos as reference
+- Companion skill: `enroll-repo-in-template` - Enable templates after onboarding


### PR DESCRIPTION
Add two complementary skills to automate common repo-templates workflows:

- onboard-new-repo: Register a new downstream repo in config.yaml
- enroll-repo-in-template: Enable an existing template for a registered repo