### PR TITLE
Trigger on mintmaker branches for rhel-coreos-config

### DIFF
--- a/find-whitespace/workflow.yaml
+++ b/find-whitespace/workflow.yaml
@@ -10,3 +10,4 @@ files:
     vars:
       branches:
         - main
+      mintmaker: true

--- a/find-whitespace/workflow.yml
+++ b/find-whitespace/workflow.yml
@@ -3,6 +3,10 @@
 name: Find Whitespace
 
 on:
+{%- if mintmaker %}
+  push:
+    branches: ['mintmaker/**']
+{%- endif %}
   pull_request:
     branches: {{ branches }}
 

--- a/shellcheck/workflow.yaml
+++ b/shellcheck/workflow.yaml
@@ -34,6 +34,7 @@ files:
     vars:
       branches:
         - main
+      mintmaker: true
 
   - repo: toolbox
     path: .github/workflows/shellcheck.yml

--- a/shellcheck/workflow.yml
+++ b/shellcheck/workflow.yml
@@ -3,6 +3,10 @@
 name: ShellCheck
 
 on:
+{%- if mintmaker %}
+  push:
+    branches: ['mintmaker/**']
+{%- endif %}
   pull_request:
     branches: {{ branches }}
 


### PR DESCRIPTION
Add conditional push trigger on 'mintmaker/**' branches for the find-whitespace and shellcheck workflows, enabled only for the rhel-coreos-config repository via the mintmaker template variable.

Assisted-by: OpenCode (Claude Opus 4)