### PR TITLE
go: merge butane signing into ignition release process

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,20 +38,6 @@ repos:
       rhel9_package: rust-bootupd
       rhel10_package: rust-bootupd
 
-  butane:
-    url: https://github.com/coreos/butane
-    vars:
-      container_needs_git_tags: true
-      containers: [quay.io/coreos/butane, quay.io/coreos/fcct]
-      git_repo: butane
-      quay_repo: coreos/butane
-      quay_legacy_repos: [coreos/fcct]
-      fedora_package: butane
-      rhaos_package: butane
-      rhel9_package: butane
-      rhel10_package: butane
-      pretty_name: Butane
-
   cap-std-ext:
     url: https://github.com/coreos/cap-std-ext
     vars:

--- a/container/container-rebuild.yaml
+++ b/container/container-rebuild.yaml
@@ -7,9 +7,6 @@
 # Don't list repos that solely ship the main branch, since those can force a
 # rebuild by just pushing a commit.
 files:
-  - repo: butane
-    path: .github/workflows/container-rebuild.yml
-
   - repo: coreos-installer
     path: .github/workflows/container-rebuild.yml
 

--- a/container/container.yaml
+++ b/container/container.yaml
@@ -8,9 +8,6 @@ files:
   - repo: airlock
     path: .github/workflows/container.yml
 
-  - repo: butane
-    path: .github/workflows/container.yml
-
   - repo: coreos-installer
     # legacy path
     path: .github/workflows/containers.yml

--- a/copr/Makefile.yaml
+++ b/copr/Makefile.yaml
@@ -4,9 +4,6 @@ files:
   - repo: afterburn
     path: .copr/Makefile
 
-  - repo: butane
-    path: .copr/Makefile
-
   - repo: coreos-installer
     path: .copr/Makefile
 

--- a/dependabot/dependabot.yaml
+++ b/dependabot/dependabot.yaml
@@ -22,11 +22,6 @@ files:
     vars:
       dependabot_labels: [area/dependencies]
 
-  - repo: butane
-    path: .github/dependabot.yml
-    vars:
-      dependabot_labels: [dependency, skip-notes]
-
   - repo: cap-std-ext
     path: .github/dependabot.yml
 

--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -2,9 +2,6 @@ files:
   - repo: afterburn
     path: docs/_config.yml
 
-  - repo: butane
-    path: docs/_config.yml
-
   - repo: coreos-assembler
     path: docs/_config.yml
 

--- a/docs/coreos.yaml
+++ b/docs/coreos.yaml
@@ -2,9 +2,6 @@ files:
   - repo: afterburn
     path: docs/_sass/color_schemes/coreos.scss
 
-  - repo: butane
-    path: docs/_sass/color_schemes/coreos.scss
-
   - repo: coreos-assembler
     path: docs/_sass/color_schemes/coreos.scss
 

--- a/gemini/config.yaml
+++ b/gemini/config.yaml
@@ -8,9 +8,6 @@ files:
   - repo: bootupd
     path: .gemini/config.yaml
 
-  - repo: butane
-    path: .gemini/config.yaml
-
   - repo: chunkah
     path: .gemini/config.yaml
 

--- a/go/release-checklist.md
+++ b/go/release-checklist.md
@@ -74,7 +74,7 @@ GitHub release:
  - [ ] Write release notes
 {%- endif %}
 {%- if sample_signing_key_update_tag %}
- - [ ] Upload all the release artifacts and their signatures
+ - [ ] Upload all the release artifacts and their signatures{% if additional_quay_repos %} (including {{ additional_quay_repos | map(attribute="name") | join(sep=", ") }} binaries){% endif %}
 {%- endif %}
  - [ ] Publish the release
 {% endif %}
@@ -85,6 +85,10 @@ Quay release:
  - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
 {%- for repo in quay_legacy_repos|default(value=[]) %}
  - [ ] Visit the [Quay tags page](https://quay.io/repository/{{ repo }}?tab=tags) for the legacy `{{ repo }}` repo and wait for a versioned tag to appear
+ - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
+{%- endfor %}
+{%- for extra in additional_quay_repos|default(value=[]) %}
+ - [ ] Visit the {{ extra.name }} [Quay tags page](https://quay.io/repository/{{ extra.repo }}?tab=tags) and wait for a versioned tag to appear
  - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm
 {%- endfor %}
 {% endif %}

--- a/go/release-checklist.yaml
+++ b/go/release-checklist.yaml
@@ -4,13 +4,6 @@ vars:
   do_release_notes_doc: true
 
 files:
-  - repo: butane
-    path: .github/ISSUE_TEMPLATE/release-checklist.md
-    vars:
-      sample_signing_key_update_tag: v0.12.0
-      do_fast_track: false
-      do_ocp_mirror: true
-
   - repo: fedora-coreos-stream-generator
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:

--- a/go/release-checklist.yaml
+++ b/go/release-checklist.yaml
@@ -14,6 +14,9 @@ files:
     path: .github/ISSUE_TEMPLATE/release-checklist.md
     vars:
       sample_signing_key_update_tag: v2.10.1
+      additional_quay_repos:
+        - name: butane
+          repo: coreos/butane
 
   - repo: stream-metadata-go
     path: .github/ISSUE_TEMPLATE/release-checklist.md

--- a/go/signing-ticket.sh
+++ b/go/signing-ticket.sh
@@ -29,27 +29,35 @@ do_sign() {
         echo INVALID > "$1.asc"
     fi
 }
+{% for target in signing_targets %}
 
-# Grab the binaries out of the redistributable rpm
-rpm="{{ signing_base }}-redistributable-${VR}.noarch.rpm"
+# Grab the {{ target.base }} binaries out of the redistributable rpm
+rpm="{{ target.base }}-redistributable-${VR}.noarch.rpm"
 koji download-build --key $RPMKEY --rpm $rpm
 rpm -Kv "$rpm" 2>&1 | grep -qi "${RPMKEY}" # Verify the output has the key in it
-rpm2cpio $rpm | cpio -idv './usr/share/{{ fedora_package }}/{{ signing_base }}-*'
+rpm2cpio $rpm | cpio -idv './usr/share/{{ target.package }}/{{ target.base }}-*'
 
-# Rename the binaries
-{%- for packaged_variant, variant in signing_variants %}
-mv usr/share/{{ fedora_package }}/{{ signing_base }}-{{ packaged_variant }} \
-    {{ signing_base }}-{{ variant }}
+# Rename the {{ target.base }} binaries
+{%- for packaged_variant, variant in target.variants %}
+mv usr/share/{{ target.package }}/{{ target.base }}-{{ packaged_variant }} \
+    {{ target.base }}-{{ variant }}
 {%- endfor %}
 
-# Sign them
-{%- for _, variant in signing_variants %}
-do_sign {{ signing_base }}-{{ variant }}
+# Sign the {{ target.base }} binaries
+{%- for _, variant in target.variants %}
+do_sign {{ target.base }}-{{ variant }}
 {%- endfor %}
+{% endfor %}
 
 # Fix permissions and clean up
 chmod go+r *.asc
-rm $rpm; rmdir ./usr/share/{{ fedora_package }}; rmdir ./usr/share; rmdir ./usr
+{%- for target in signing_targets %}
+rm {{ target.base }}-redistributable-*.rpm
+{%- endfor %}
+{%- for target in signing_targets %}
+rmdir ./usr/share/{{ target.package }}
+{%- endfor %}
+rmdir ./usr/share ./usr
 EOF
 }
 
@@ -69,17 +77,19 @@ EOF
 
 After running this you should end up with a directory with files in it like:
 
-{# create array of map values for sorting #}
-{% set_global variant_values = [] %}
-{% for _, variant in signing_variants %}
-{% set_global variant_values = variant_values | concat(with=variant) %}
+{# create array of all variant values for sorting #}
+{% set_global all_variants = [] %}
+{% for target in signing_targets %}
+{% for _, variant in target.variants %}
+{% set_global all_variants = all_variants | concat(with=target.base ~ "-" ~ variant) %}
+{% endfor %}
 {% endfor %}
 
 ```
 $ ls -1
-{%- for variant in variant_values | sort %}
-{{ signing_base }}-{{ variant }}
-{{ signing_base }}-{{ variant }}.asc
+{%- for variant in all_variants | sort %}
+{{ variant }}
+{{ variant }}.asc
 {%- endfor %}
 ```
 EOF

--- a/go/signing-ticket.yaml
+++ b/go/signing-ticket.yaml
@@ -1,30 +1,30 @@
 files:
-  - repo: butane
-    path: signing-ticket.sh
-    vars:
-      signing_base: butane
-      signing_variants:
-        aarch64-unknown-linux-gnu-static: aarch64-unknown-linux-gnu
-        ppc64le-unknown-linux-gnu-static: ppc64le-unknown-linux-gnu
-        s390x-unknown-linux-gnu-static: s390x-unknown-linux-gnu
-        x86_64-unknown-linux-gnu-static: x86_64-unknown-linux-gnu
-
-        aarch64-apple-darwin: aarch64-apple-darwin
-        x86_64-apple-darwin: x86_64-apple-darwin
-
-        "x86_64-pc-windows-gnu.exe": "x86_64-pc-windows-gnu.exe"
-
   - repo: ignition
     path: signing-ticket.sh
     vars:
-      signing_base: ignition-validate
-      signing_variants:
-        aarch64-unknown-linux-gnu-static: aarch64-linux
-        ppc64le-unknown-linux-gnu-static: ppc64le-linux
-        s390x-unknown-linux-gnu-static: s390x-linux
-        x86_64-unknown-linux-gnu-static: x86_64-linux
+      signing_targets:
+        - base: ignition-validate
+          package: ignition
+          variants:
+            aarch64-unknown-linux-gnu-static: aarch64-linux
+            ppc64le-unknown-linux-gnu-static: ppc64le-linux
+            s390x-unknown-linux-gnu-static: s390x-linux
+            x86_64-unknown-linux-gnu-static: x86_64-linux
 
-        aarch64-apple-darwin: aarch64-apple-darwin
-        x86_64-apple-darwin: x86_64-apple-darwin
+            aarch64-apple-darwin: aarch64-apple-darwin
+            x86_64-apple-darwin: x86_64-apple-darwin
 
-        "x86_64-pc-windows-gnu.exe": "x86_64-pc-windows-gnu.exe"
+            "x86_64-pc-windows-gnu.exe": "x86_64-pc-windows-gnu.exe"
+
+        - base: butane
+          package: butane
+          variants:
+            aarch64-unknown-linux-gnu-static: aarch64-unknown-linux-gnu
+            ppc64le-unknown-linux-gnu-static: ppc64le-unknown-linux-gnu
+            s390x-unknown-linux-gnu-static: s390x-unknown-linux-gnu
+            x86_64-unknown-linux-gnu-static: x86_64-unknown-linux-gnu
+
+            aarch64-apple-darwin: aarch64-apple-darwin
+            x86_64-apple-darwin: x86_64-apple-darwin
+
+            "x86_64-pc-windows-gnu.exe": "x86_64-pc-windows-gnu.exe"

--- a/go/tag_release.yaml
+++ b/go/tag_release.yaml
@@ -1,11 +1,6 @@
 # Script for tagging a release in Git
 
 files:
-  - repo: butane
-    path: tag_release.sh
-    vars:
-      tag_project_name: Butane
-
   - repo: fedora-coreos-stream-generator
     path: tag_release.sh
 

--- a/go/tests.yaml
+++ b/go/tests.yaml
@@ -11,15 +11,6 @@ files:
   - repo: airlock
     path: .github/workflows/go.yml
 
-  - repo: butane
-    path: .github/workflows/go.yml
-    vars:
-      do_multi_os: true
-      brew_dependencies: [coreutils]
-      go_build_cmd: ~
-      go_test_cmd: ./test
-      go_generated_dirs: [docs]
-
   - repo: fedora-coreos-stream-generator
     path: .github/workflows/go.yml
     vars:

--- a/release-notes/require-release-note.yaml
+++ b/release-notes/require-release-note.yaml
@@ -6,9 +6,6 @@ files:
   - repo: afterburn
     path: .github/workflows/require-release-note.yml
 
-  - repo: butane
-    path: .github/workflows/require-release-note.yml
-
   - repo: coreos-installer
     path: .github/workflows/require-release-note.yml
 


### PR DESCRIPTION
Butane has been merged into the Ignition repository ([coreos/ignition#2235](https://github.com/coreos/ignition/pull/2235)) and the standalone butane repo has been archived. This PR updates repo-templates to reflect that:

1. Butane signing is now part of the ignition release process
2. The butane repo should no longer receive any templated files


Commit 1: Merge butane signing into ignition

- **`go/signing-ticket.sh`**: Refactored template to support a `signing_targets` list instead of a single `signing_base`. Each target has its own `base`, `package`, and `variants`. This allows the ignition signing ticket to handle both `ignition-validate-redistributable` and `butane-redistributable` RPMs in one ticket.
- **`go/signing-ticket.yaml`**: Removed butane entry. Updated ignition entry to use the new `signing_targets` format with both ignition-validate and butane targets.
- **`go/tag_release.yaml`**: Removed butane entry since butane releases are now part of ignition releases.

Commit 2: Remove butane from all template metadata

Removed `repo: butane` entries from all 13 remaining template metadata files so the sync workflow no longer targets the archived repo:

`config.yaml`, `container/container-rebuild.yaml`, `container/container.yaml`, `copr/Makefile.yaml`, `dependabot/dependabot.yaml`, `docs/_config.yaml`, `docs/coreos.yaml`, `gemini/config.yaml`, `go/release-checklist.yaml`, `go/tests.yaml`, `markdownlint/config.yaml`, `markdownlint/workflow.yaml`, `release-notes/require-release-note.yaml`


The ignition `signing-ticket.sh` now extracts, renames, and signs both ignition-validate and butane binaries in a single releng ticket. No output is generated for the butane repo.

- Closes https://github.com/coreos/ignition/issues/2254
- Related: https://github.com/coreos/fedora-coreos-tracker/issues/2006