### PR TITLE
container: support additional container images per repo

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -154,6 +154,10 @@ repos:
       container_file: Dockerfile.validate
       container_needs_git_tags: true
       containers: [quay.io/coreos/ignition-validate]
+      additional_containers:
+        - name: butane
+          file: butane/Dockerfile
+          push: [quay.io/coreos/butane]
       git_repo: ignition
       quay_repo: coreos/ignition-validate
       fedora_package: ignition

--- a/container/container-rebuild.yml
+++ b/container/container-rebuild.yml
@@ -51,3 +51,28 @@ jobs:
           push: {{ containers | join(sep=" ") }}
           arches: {{ container_arches | join(sep=" ") }}
           tags: {% raw %}${{ github.event.inputs.docker-tag }}{% endraw %} release
+{% for extra in additional_containers | default(value=[]) %}
+
+  build-container-{{ extra.name }}:
+    name: Build {{ extra.name }} container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: {% raw %}${{ github.event.inputs.git-tag }}{% endraw %}
+{%- if container_needs_git_tags %}
+          # fetch tags so the compiled-in version number is useful
+          fetch-depth: 0
+      - name: Fix actions/checkout synthetic tag
+        run: git fetch --tags --force
+{%- endif %}
+      - name: Build and push container
+        uses: coreos/actions-lib/build-container@main
+        with:
+          credentials: {% raw %}${{ secrets.QUAY_AUTH }}{% endraw %}
+          file: {{ extra.file }}
+          push: {{ extra.push | join(sep=" ") }}
+          arches: {{ container_arches | join(sep=" ") }}
+          tags: {% raw %}${{ github.event.inputs.docker-tag }}{% endraw %} release
+{%- endfor %}

--- a/container/container.yml
+++ b/container/container.yml
@@ -51,3 +51,30 @@ jobs:
           # Speed up PR CI by skipping non-amd64
           pr-arches: amd64
 {%- endif %}
+{% for extra in additional_containers | default(value=[]) %}
+
+  build-container-{{ extra.name }}:
+    name: Build {{ extra.name }} container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+{%- if container_needs_git_tags %}
+        with:
+          # fetch tags so the compiled-in version number is useful
+          fetch-depth: 0
+      - name: Fix actions/checkout synthetic tag
+        run: git fetch --tags --force
+{%- endif %}
+      - name: Build and push container
+        uses: coreos/actions-lib/build-container@main
+        with:
+          credentials: {% raw %}${{ secrets.QUAY_AUTH }}{% endraw %}
+          file: {{ extra.file }}
+          push: {{ extra.push | join(sep=" ") }}
+          arches: {{ container_arches | join(sep=" ") }}
+{%-if container_arches.0 != 'amd64' or container_arches.1 %}
+          # Speed up PR CI by skipping non-amd64
+          pr-arches: amd64
+{%- endif %}
+{%- endfor %}


### PR DESCRIPTION
## Summary

Add support for repos that need to build multiple container images from different Dockerfiles. This is needed for ignition, which now builds both `ignition-validate` and `butane` containers from the same repo after the Butane merge (#2235).

## Changes

- **`container/container.yml`** -- Add a `{% for %}` loop over `additional_containers` that renders extra jobs, each with its own Dockerfile and push target
- **`container/container-rebuild.yml`** -- Same change for the rebuild workflow
- **`config.yaml`** -- Add `additional_containers` to ignition's config with the butane container (`Dockerfile.butane` -> `quay.io/coreos/butane`)

## Rendered output

Ignition's `container.yml` now has two jobs:
- `build-container` -- builds `Dockerfile.validate`, pushes to `quay.io/coreos/ignition-validate` (unchanged)
- `build-container-butane` -- builds `Dockerfile.butane`, pushes to `quay.io/coreos/butane` (new)

Other repos are unaffected (`additional_containers` defaults to an empty list).

## Related

- Tracking: https://github.com/coreos/fedora-coreos-tracker/issues/2006